### PR TITLE
client: pass a spec to the multi client

### DIFF
--- a/client/device.go
+++ b/client/device.go
@@ -321,26 +321,6 @@ func (self *BringYourDevice) RemoveDestination() error {
 	return self.SetDestination(nil, ProvideModeNone)
 }
 
-func (self *BringYourDevice) SetDestinationPublicClientIds(clientIds *IdList) error {
-	specs := NewProviderSpecList()
-	for i := 0; i < clientIds.Len(); i += 1 {
-		specs.Add(&ProviderSpec{
-			ClientId: clientIds.Get(i),
-		})
-	}
-	return self.SetDestination(specs, ProvideModePublic)
-}
-
-/*
-func (self *BringYourDevice) SetDestinationPublicClientId(clientId *Id) error {
-	specs := NewProviderSpecList()
-	specs.Add(&ProviderSpec{
-		ClientId: clientId,
-	})
-	return self.SetDestination(specs, ProvideModePublic)
-}
-*/
-
 func (self *BringYourDevice) SetDestination(specs *ProviderSpecList, provideMode ProvideMode) (returnErr error) {
 	func() {
 		self.stateLock.Lock()
@@ -379,6 +359,7 @@ func (self *BringYourDevice) SetDestination(specs *ProviderSpecList, provideMode
 			} else {
 				generator := connect.NewApiMultiClientGenerator(
 					connectSpecs,
+					[]connect.Id{self.clientId},
 					self.apiUrl,
 					self.byJwt,
 					self.platformUrl,


### PR DESCRIPTION
The list of client ids is static and will not update over time. Hence the multi client that is initialized with a fixed list will not be resilient to changing providers. The fix is to give the multi client the specs so that it can evaluate matches at each enumeration step.

Also clean up superfluous code in device and connect view controler.

fix https://github.com/bringyour/bringyour/issues/33

Depends on https://github.com/bringyour/connect/pull/24