### PR TITLE
subscription_controller: data code skus move to config

### DIFF
--- a/bringyour/controller/subscription_controller.go
+++ b/bringyour/controller/subscription_controller.go
@@ -74,7 +74,7 @@ func parseVaultSkus(skusInterface []interface{}) []VaultSku {
 }
 
 var vaultStripeSkus = sync.OnceValue(func() []VaultSku {
-	c := bringyour.Vault.RequireSimpleResource("stripe.yml").Parse()
+	c := bringyour.Config.RequireSimpleResource("stripe.yml").Parse()
 
 	return parseVaultSkus(c["skus"].([]interface{}))
 })
@@ -107,7 +107,7 @@ var coinbaseWebhookSharedSecret = sync.OnceValue(func() string {
 })
 
 var vaultCoinbaseSkus = sync.OnceValue(func() []VaultSku {
-	c := bringyour.Vault.RequireSimpleResource("coinbase.yml").Parse()
+	c := bringyour.Config.RequireSimpleResource("coinbase.yml").Parse()
 
 	return parseVaultSkus(c["skus"].([]interface{}))
 })


### PR DESCRIPTION
Skus aren't sensistive so we can store them in config versus vault. Config is deployed differently than vault, and is easier to update without using escalated privileges.

Config is deployed using the config updater. New config patches into the currently running services. e.g.

```
warpctl build main warp/config-updates/Makefile
warpctl deploy main config-updater ...
```

Vault is deployed using the ansible deployment. It restarts the running services but is more of a system rewrite. Not all devs will be able to do this type of deployment, so ideally we limit the number of ansible deployments we have to do. e.g.

```
cd xops/main/ansible
./run.sh
``
