### PR TITLE
separates locations and connection into separate vms

### DIFF
--- a/client/connect_view_controller.go
+++ b/client/connect_view_controller.go
@@ -1,14 +1,10 @@
+// todo - deprecate in favor of connect_view_model
+
 package client
 
 import (
 	"context"
 
-	"crypto/md5"
-	"fmt"
-
-	"slices"
-	"sort"
-	"strings"
 	"sync"
 
 	"golang.org/x/mobile/gl"
@@ -18,30 +14,6 @@ import (
 
 var cvcLog = logFn("connect_view_controller")
 
-type ConnectionStatus = string
-
-const (
-	Disconnected ConnectionStatus = "DISCONNECTED"
-	Connecting   ConnectionStatus = "CONNECTING"
-	Connected    ConnectionStatus = "CONNECTED"
-	Canceling    ConnectionStatus = "CANCELING"
-)
-
-type SelectedLocationListener interface {
-	SelectedLocationChanged(location *ConnectLocation)
-}
-
-type ConnectionStatusListener interface {
-	ConnectionStatusChanged(status ConnectionStatus)
-}
-
-type FilteredLocationsListener interface {
-	FilteredLocationsChanged()
-}
-
-type ConnectedProviderCountListener interface {
-	ConnectedProviderCountChanged(count int32)
-}
 type ConnectViewController struct {
 	glViewController
 
@@ -52,7 +24,6 @@ type ConnectViewController struct {
 	stateLock sync.Mutex
 
 	selectedLocation             *ConnectLocation
-	locations                    *ConnectLocationList
 	connectionStatus             ConnectionStatus
 	nextFilterSequenceNumber     int64
 	previousFilterSequenceNumber int64
@@ -60,7 +31,6 @@ type ConnectViewController struct {
 
 	selectedLocationListeners       *connect.CallbackList[SelectedLocationListener]
 	connectionStatusListeners       *connect.CallbackList[ConnectionStatusListener]
-	filteredLocationListeners       *connect.CallbackList[FilteredLocationsListener]
 	connectedProviderCountListeners *connect.CallbackList[ConnectedProviderCountListener]
 }
 
@@ -75,14 +45,12 @@ func newConnectViewController(ctx context.Context, device *BringYourDevice) *Con
 
 		nextFilterSequenceNumber:     0,
 		previousFilterSequenceNumber: 0,
-		locations:                    NewConnectLocationList(),
 		connectionStatus:             Disconnected,
 		selectedLocation:             nil,
 		connectedProviderCount:       0,
 
 		selectedLocationListeners:       connect.NewCallbackList[SelectedLocationListener](),
 		connectionStatusListeners:       connect.NewCallbackList[ConnectionStatusListener](),
-		filteredLocationListeners:       connect.NewCallbackList[FilteredLocationsListener](),
 		connectedProviderCountListeners: connect.NewCallbackList[ConnectedProviderCountListener](),
 	}
 	vc.drawController = vc
@@ -90,26 +58,10 @@ func newConnectViewController(ctx context.Context, device *BringYourDevice) *Con
 }
 
 func (self *ConnectViewController) Start() {
-	// var activeLocation *ConnectLocation
-	// self.stateLock.Lock()
-	// activeLocation = self.activeLocation
-	// self.stateLock.Unlock()
-
-	// self.connectionChanged(activeLocation, activeLocation != nil)
-
-	// TODO filtered results
-
-	self.FilterLocations("")
 }
 
 func (self *ConnectViewController) Stop() {
 	// FIXME
-}
-
-func (self *ConnectViewController) GetLocations() *ConnectLocationList {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-	return self.locations
 }
 
 func (self *ConnectViewController) GetConnectionStatus() ConnectionStatus {
@@ -125,26 +77,10 @@ func (self *ConnectViewController) setConnectionStatus(status ConnectionStatus) 
 	self.connectionStatusChanged(status)
 }
 
-func (self *ConnectViewController) AddFilteredLocationsListener(listener FilteredLocationsListener) Sub {
-	callbackId := self.filteredLocationListeners.Add(listener)
-	return newSub(func() {
-		self.filteredLocationListeners.Remove(callbackId)
-	})
-}
-
-// `FilteredLocationsListener`
-func (self *ConnectViewController) filteredLocationsChanged() {
-	for _, listener := range self.filteredLocationListeners.Get() {
-		connect.HandleError(func() {
-			listener.FilteredLocationsChanged()
-		})
-	}
-}
-
-func (self *ConnectViewController) connectionStatusChanged(status ConnectionStatus) {
+func (self *ConnectViewController) connectionStatusChanged(_ ConnectionStatus) {
 	for _, listener := range self.connectionStatusListeners.Get() {
 		connect.HandleError(func() {
-			listener.ConnectionStatusChanged(status)
+			listener.ConnectionStatusChanged()
 		})
 	}
 }
@@ -240,7 +176,6 @@ func (self *ConnectViewController) Connect(location *ConnectLocation) {
 		self.selectedLocation = location
 	}()
 
-	// self.setSelectedLocation(location)
 	self.setConnectionStatus(Connecting)
 
 	if location.IsDevice() {
@@ -379,126 +314,6 @@ func (self *ConnectViewController) Disconnect() {
 	self.connectionStatusChanged(Disconnected)
 }
 
-func (self *ConnectViewController) FilterLocations(filter string) {
-	// api call, call callback
-	filter = strings.TrimSpace(filter)
-
-	cvcLog("FILTER LOCATIONS %s", filter)
-
-	var filterSequenceNumber int64
-	self.stateLock.Lock()
-	self.nextFilterSequenceNumber += 1
-	filterSequenceNumber = self.nextFilterSequenceNumber
-	self.stateLock.Unlock()
-
-	cvcLog("POST FILTER LOCATIONS %s", filter)
-
-	if filter == "" {
-		self.device.Api().GetProviderLocations(FindLocationsCallback(newApiCallback[*FindLocationsResult](
-			func(result *FindLocationsResult, err error) {
-				cvcLog("FIND LOCATIONS RESULT %s %s", result, err)
-				if err == nil {
-					var update bool
-					self.stateLock.Lock()
-					if self.previousFilterSequenceNumber < filterSequenceNumber {
-						self.previousFilterSequenceNumber = filterSequenceNumber
-						update = true
-					}
-					self.stateLock.Unlock()
-
-					if update {
-						self.setFilteredLocationsFromResult(result)
-					}
-				}
-			},
-		)))
-	} else {
-		findLocations := &FindLocationsArgs{
-			Query: filter,
-		}
-		self.device.Api().FindProviderLocations(findLocations, FindLocationsCallback(newApiCallback[*FindLocationsResult](
-			func(result *FindLocationsResult, err error) {
-				cvcLog("FIND LOCATIONS RESULT %s %s", result, err)
-				if err == nil {
-					var update bool
-					self.stateLock.Lock()
-					if self.previousFilterSequenceNumber < filterSequenceNumber {
-						self.previousFilterSequenceNumber = filterSequenceNumber
-						update = true
-					}
-					self.stateLock.Unlock()
-
-					if update {
-						self.setFilteredLocationsFromResult(result)
-					}
-				}
-			},
-		)))
-	}
-}
-
-func (self *ConnectViewController) setFilteredLocationsFromResult(result *FindLocationsResult) {
-	cvcLog("SET FILTERED LOCATIONS FROM RESULT %s", result)
-
-	locations := []*ConnectLocation{}
-
-	for i := 0; i < result.Groups.Len(); i += 1 {
-		groupResult := result.Groups.Get(i)
-
-		location := &ConnectLocation{
-			ConnectLocationId: &ConnectLocationId{
-				LocationGroupId: groupResult.LocationGroupId,
-			},
-			Name:          groupResult.Name,
-			ProviderCount: int32(groupResult.ProviderCount),
-			Promoted:      groupResult.Promoted,
-			MatchDistance: int32(groupResult.MatchDistance),
-		}
-		locations = append(locations, location)
-	}
-
-	for i := 0; i < result.Locations.Len(); i += 1 {
-		locationResult := result.Locations.Get(i)
-
-		location := &ConnectLocation{
-			ConnectLocationId: &ConnectLocationId{
-				LocationId: locationResult.LocationId,
-			},
-			LocationType:      locationResult.LocationType,
-			Name:              locationResult.Name,
-			City:              locationResult.City,
-			Region:            locationResult.Region,
-			Country:           locationResult.Country,
-			CountryCode:       locationResult.CountryCode,
-			CityLocationId:    locationResult.CityLocationId,
-			RegionLocationId:  locationResult.RegionLocationId,
-			CountryLocationId: locationResult.CountryLocationId,
-			ProviderCount:     int32(locationResult.ProviderCount),
-			MatchDistance:     int32(locationResult.MatchDistance),
-		}
-		locations = append(locations, location)
-	}
-
-	for i := 0; i < result.Devices.Len(); i += 1 {
-		locationDeviceResult := result.Devices.Get(i)
-
-		location := &ConnectLocation{
-			ConnectLocationId: &ConnectLocationId{
-				ClientId: locationDeviceResult.ClientId,
-			},
-			Name: locationDeviceResult.DeviceName,
-		}
-		locations = append(locations, location)
-	}
-
-	slices.SortStableFunc(locations, cmpConnectLocationLayout)
-
-	exportedFilteredLocations := NewConnectLocationList()
-	exportedFilteredLocations.addAll(locations...)
-	self.locations = exportedFilteredLocations
-	self.filteredLocationsChanged()
-}
-
 func (self *ConnectViewController) draw(g gl.Context) {
 	// cvcLog("draw")
 
@@ -517,287 +332,4 @@ func (self *ConnectViewController) Close() {
 	cvcLog("close")
 
 	self.cancel()
-}
-
-func cmpConnectLocationLayout(a *ConnectLocation, b *ConnectLocation) int {
-	// sort locations
-	// - provider count descending
-	// - name
-
-	if a == b {
-		return 0
-	}
-
-	// provider count descending
-	if a.ProviderCount != b.ProviderCount {
-		if a.ProviderCount < b.ProviderCount {
-			return 1
-		} else {
-			return -1
-		}
-	}
-
-	if a.Name != b.Name {
-		if a.Name < b.Name {
-			return -1
-		} else {
-			return 1
-		}
-	}
-
-	return a.ConnectLocationId.Cmp(b.ConnectLocationId)
-
-}
-
-// merged location and location group
-type ConnectLocation struct {
-	ConnectLocationId *ConnectLocationId
-	Name              string
-
-	ProviderCount int32
-	Promoted      bool
-	MatchDistance int32
-
-	LocationType LocationType
-
-	City        string
-	Region      string
-	Country     string
-	CountryCode string
-
-	CityLocationId    *Id
-	RegionLocationId  *Id
-	CountryLocationId *Id
-}
-
-func (self *ConnectLocation) IsGroup() bool {
-	return self.ConnectLocationId.IsGroup()
-}
-
-func (self *ConnectLocation) IsDevice() bool {
-	return self.ConnectLocationId.IsDevice()
-}
-
-func (self *ConnectLocation) ToRegion() *ConnectLocation {
-	return &ConnectLocation{
-		ConnectLocationId: self.ConnectLocationId,
-		Name:              self.Region,
-
-		ProviderCount: self.ProviderCount,
-		Promoted:      false,
-		MatchDistance: 0,
-
-		LocationType: LocationTypeRegion,
-
-		City:        "",
-		Region:      self.Region,
-		Country:     self.Country,
-		CountryCode: self.CountryCode,
-
-		CityLocationId:    nil,
-		RegionLocationId:  self.RegionLocationId,
-		CountryLocationId: self.CountryLocationId,
-	}
-}
-
-func (self *ConnectLocation) ToCountry() *ConnectLocation {
-	return &ConnectLocation{
-		ConnectLocationId: self.ConnectLocationId,
-		Name:              self.Country,
-
-		ProviderCount: self.ProviderCount,
-		Promoted:      false,
-		MatchDistance: 0,
-
-		LocationType: LocationTypeCountry,
-
-		City:        "",
-		Region:      "",
-		Country:     self.Country,
-		CountryCode: self.CountryCode,
-
-		CityLocationId:    nil,
-		RegionLocationId:  nil,
-		CountryLocationId: self.CountryLocationId,
-	}
-}
-
-/**
- * Code is usually the country code which maps to a color hex.
- * If the location is not a country, we just need a unique string that represents the location
- * ie locationId.toString()
- */
-func (self *ConnectViewController) GetColorHex(code string) string {
-
-	if color, exists := countryCodeColorHexes[code]; exists {
-		return color
-	}
-
-	/**
-	 * Fallback if color hex isn't found, generate a new one by mixing two colors together
-	 */
-	keys := make([]string, 0, len(countryCodeColorHexes))
-	for k := range countryCodeColorHexes {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	index1 := getHashIndex(code, len(keys))
-	index2 := getHashIndex(code+"salt", len(keys))
-
-	color1 := countryCodeColorHexes[keys[index1]]
-	color2 := countryCodeColorHexes[keys[index2]]
-
-	return mixColors(color1, color2)
-}
-
-// to get a consistent index from the id
-func getHashIndex(id string, mod int) int {
-	hash := md5.Sum([]byte(id))
-	return int(hash[0]) % mod
-}
-
-func mixColors(color1, color2 string) string {
-	r1, g1, b1 := hexToRGB(color1)
-	r2, g2, b2 := hexToRGB(color2)
-
-	// Mix the colors by averaging their RGB components
-	r := (r1 + r2) / 2
-	g := (g1 + g2) / 2
-	b := (b1 + b2) / 2
-
-	return rgbToHex(r, g, b)
-}
-
-func hexToRGB(hex string) (int, int, int) {
-	var r, g, b int
-	fmt.Sscanf(hex, "%02x%02x%02x", &r, &g, &b)
-	return r, g, b
-}
-
-func rgbToHex(r, g, b int) string {
-	return fmt.Sprintf("%02x%02x%02x", r, g, b)
-}
-
-var countryCodeColorHexes = map[string]string{
-	"is": "639A88",
-	"ee": "78C0E0",
-	"ca": "449DD1",
-	"de": "663F46",
-	"au": "F29E4C",
-	"us": "BAC5B3",
-	"gb": "F1789B",
-	"jp": "CC3363",
-	"ie": "7EE081",
-	"fi": "F56E48",
-	"nl": "F56E48",
-	"se": "A4C4F4",
-	"fr": "A864DC",
-	"it": "F9F871",
-	"dk": "D6E6F4",
-	"no": "BCE5DC",
-	"be": "9B4A91",
-	"at": "FFCB68",
-	"ch": "FFABA0",
-	"nz": "008A64",
-	"pt": "248C89",
-	"es": "B41F43",
-	"lv": "EEE8A9",
-	"lt": "8179E0",
-	"cz": "99E8CE",
-	"si": "FF6C58",
-	"sk": "87FB67",
-	"pl": "D38B5D",
-	"hu": "FF8484",
-	"hr": "99B2DD",
-	"ro": "C6362F",
-	"bg": "A1CDF4",
-	"gr": "C874D9",
-	"cy": "E1BBC9",
-	"mt": "FFC43D",
-	"il": "A9E4EF",
-	"za": "F2B79F",
-	"ar": "8E8DBE",
-	"br": "DCD6F7",
-	"cl": "FA824C",
-	"cr": "E07A5F",
-	"uy": "7FDEFF",
-	"jm": "7B886F",
-	"tt": "0072BB",
-	"gh": "1098F7",
-	"ke": "F2EDEB",
-	"ng": "64113F",
-	"tn": "6B4D57",
-	"sn": "596869",
-	"na": "813405",
-	"bw": "D45113",
-	"mu": "60E1E0",
-	"mg": "F25D72",
-	"in": "F2E2D2",
-	"kr": "C320D9",
-	"tw": "E6EA23",
-	"my": "3A1772",
-	"ph": "B4CEB3",
-	"id": "586189",
-	"mn": "A6A57A",
-	"ge": "679436",
-	"am": "F2B5D4",
-	"ua": "00F28D",
-	"md": "7F675B",
-	"me": "E5FFDE",
-	"rs": "FF495C",
-	"al": "E4B363",
-}
-
-// merged location and location group
-type ConnectLocationId struct {
-	// if set, the location is a direct connection to another device
-	ClientId        *Id
-	LocationId      *Id
-	LocationGroupId *Id
-}
-
-func (self *ConnectLocationId) IsGroup() bool {
-	return self.LocationGroupId != nil
-}
-
-func (self *ConnectLocationId) IsDevice() bool {
-	return self.ClientId != nil
-}
-
-func (self *ConnectLocationId) Cmp(b *ConnectLocationId) int {
-	// - direct
-	// - group
-	if self.ClientId != nil && b.ClientId != nil {
-		if c := self.ClientId.Cmp(b.ClientId); c != 0 {
-			return c
-		}
-	} else if self.ClientId != nil {
-		return -1
-	} else if b.ClientId != nil {
-		return 1
-	}
-
-	if self.LocationGroupId != nil && b.LocationGroupId != nil {
-		if c := self.LocationGroupId.Cmp(b.LocationGroupId); c != 0 {
-			return c
-		}
-	} else if self.LocationGroupId != nil {
-		return -1
-	} else if b.LocationGroupId != nil {
-		return 1
-	}
-
-	if self.LocationId != nil && b.LocationId != nil {
-		if c := self.LocationId.Cmp(b.LocationId); c != 0 {
-			return c
-		}
-	} else if self.LocationId != nil {
-		return -1
-	} else if b.LocationId != nil {
-		return 1
-	}
-
-	return 0
 }

--- a/client/connect_view_model.go
+++ b/client/connect_view_model.go
@@ -1,0 +1,471 @@
+package client
+
+import (
+	"context"
+
+	"sync"
+
+	"bringyour.com/connect"
+)
+
+var cvmLog = logFn("connect_view_model")
+
+type ConnectionStatus = string
+
+const (
+	Disconnected ConnectionStatus = "DISCONNECTED"
+	Connecting   ConnectionStatus = "CONNECTING"
+	Connected    ConnectionStatus = "CONNECTED"
+	Canceling    ConnectionStatus = "CANCELING"
+)
+
+type SelectedLocationListener interface {
+	SelectedLocationChanged(location *ConnectLocation)
+}
+
+type ConnectionStatusListener interface {
+	ConnectionStatusChanged()
+}
+
+// type FilteredLocationsListener interface {
+// 	FilteredLocationsChanged()
+// }
+
+type ConnectedProviderCountListener interface {
+	ConnectedProviderCountChanged(count int32)
+}
+
+type ConnectViewModel struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	device *BringYourDevice
+
+	stateLock sync.Mutex
+
+	selectedLocation       *ConnectLocation
+	connectionStatus       ConnectionStatus
+	connectedProviderCount int32
+
+	selectedLocationListeners       *connect.CallbackList[SelectedLocationListener]
+	connectionStatusListeners       *connect.CallbackList[ConnectionStatusListener]
+	connectedProviderCountListeners *connect.CallbackList[ConnectedProviderCountListener]
+}
+
+func newConnectViewModel(ctx context.Context, device *BringYourDevice) *ConnectViewModel {
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	vm := &ConnectViewModel{
+		ctx:    cancelCtx,
+		cancel: cancel,
+		device: device,
+
+		connectionStatus:       Disconnected,
+		selectedLocation:       nil,
+		connectedProviderCount: 0,
+
+		selectedLocationListeners:       connect.NewCallbackList[SelectedLocationListener](),
+		connectionStatusListeners:       connect.NewCallbackList[ConnectionStatusListener](),
+		connectedProviderCountListeners: connect.NewCallbackList[ConnectedProviderCountListener](),
+	}
+	return vm
+}
+
+func (vm *ConnectViewModel) Start() {
+	// var activeLocation *ConnectLocation
+	// self.stateLock.Lock()
+	// activeLocation = self.activeLocation
+	// self.stateLock.Unlock()
+
+	// self.connectionChanged(activeLocation, activeLocation != nil)
+
+	// TODO filtered results
+
+	// self.FilterLocations("")
+}
+
+func (vm *ConnectViewModel) Stop() {
+	// FIXME
+}
+
+func (vm *ConnectViewModel) Close() {
+	cvmLog("close")
+
+	vm.cancel()
+}
+
+func (vm *ConnectViewModel) GetConnectionStatus() ConnectionStatus {
+	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
+	return vm.connectionStatus
+}
+
+func (vm *ConnectViewModel) setConnectionStatus(status ConnectionStatus) {
+	func() {
+		vm.stateLock.Lock()
+		defer vm.stateLock.Unlock()
+		vm.connectionStatus = status
+	}()
+	vm.connectionStatusChanged()
+}
+
+func (vm *ConnectViewModel) connectionStatusChanged() {
+	for _, listener := range vm.connectionStatusListeners.Get() {
+		connect.HandleError(func() {
+			listener.ConnectionStatusChanged()
+		})
+	}
+}
+
+func (vm *ConnectViewModel) AddConnectionStatusListener(listener ConnectionStatusListener) Sub {
+	callbackId := vm.connectionStatusListeners.Add(listener)
+	return newSub(func() {
+		vm.connectionStatusListeners.Remove(callbackId)
+	})
+}
+
+func (vm *ConnectViewModel) AddSelectedLocationListener(listener SelectedLocationListener) Sub {
+	callbackId := vm.selectedLocationListeners.Add(listener)
+	return newSub(func() {
+		vm.selectedLocationListeners.Remove(callbackId)
+	})
+}
+
+func (vm *ConnectViewModel) setSelectedLocation(location *ConnectLocation) {
+	func() {
+		vm.stateLock.Lock()
+		defer vm.stateLock.Unlock()
+		vm.selectedLocation = location
+	}()
+	vm.selectedLocationChanged(location)
+}
+
+func (vm *ConnectViewModel) GetSelectedLocation() *ConnectLocation {
+	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
+	return vm.selectedLocation
+}
+
+func (vm *ConnectViewModel) selectedLocationChanged(location *ConnectLocation) {
+	for _, listener := range vm.selectedLocationListeners.Get() {
+		connect.HandleError(func() {
+			listener.SelectedLocationChanged(location)
+		})
+	}
+}
+
+func (vm *ConnectViewModel) AddConnectedProviderCountListener(listener ConnectedProviderCountListener) Sub {
+	callbackId := vm.connectedProviderCountListeners.Add(listener)
+	return newSub(func() {
+		vm.connectedProviderCountListeners.Remove(callbackId)
+	})
+}
+
+// `FilteredLocationsListener`
+func (vm *ConnectViewModel) connectedProviderCountChanged(count int32) {
+	for _, listener := range vm.connectedProviderCountListeners.Get() {
+		connect.HandleError(func() {
+			listener.ConnectedProviderCountChanged(count)
+		})
+	}
+}
+
+func (vm *ConnectViewModel) setConnectedProviderCount(count int32) {
+	func() {
+		vm.stateLock.Lock()
+		defer vm.stateLock.Unlock()
+		vm.connectedProviderCount = count
+	}()
+	vm.connectedProviderCountChanged(count)
+}
+
+func (vm *ConnectViewModel) GetConnectedProviderCount() int32 {
+	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
+	return vm.connectedProviderCount
+}
+
+// FIXME ConnectWithSpecs(SpecList)
+
+func (vm *ConnectViewModel) isCanceling() bool {
+	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
+	isCanceling := false
+	if vm.connectionStatus == Canceling {
+		isCanceling = true
+	}
+	return isCanceling
+}
+
+func (vm *ConnectViewModel) Connect(location *ConnectLocation) {
+	// api call to get client ids, device.SETLOCATION
+	// call callback
+
+	// TODO store the connected locationId
+	// TODO reset clientIds
+
+	func() {
+		vm.stateLock.Lock()
+		defer vm.stateLock.Unlock()
+		vm.selectedLocation = location
+	}()
+
+	// self.setSelectedLocation(location)
+	vm.setConnectionStatus(Connecting)
+
+	if location.IsDevice() {
+
+		isCanceling := vm.isCanceling()
+
+		if isCanceling {
+			vm.setConnectionStatus(Disconnected)
+		} else {
+			destinationIds := []Id{
+				*location.ConnectLocationId.ClientId,
+			}
+
+			specs := NewProviderSpecList()
+			for _, destinationId := range destinationIds {
+				specs.Add(&ProviderSpec{
+					ClientId: &destinationId,
+				})
+			}
+			vm.device.SetDestination(specs, ProvideModePublic)
+			vm.setSelectedLocation(location)
+			vm.setConnectionStatus(Connected)
+		}
+
+	} else {
+		specs := NewProviderSpecList()
+		specs.Add(&ProviderSpec{
+			LocationId:      location.ConnectLocationId.LocationId,
+			LocationGroupId: location.ConnectLocationId.LocationGroupId,
+		})
+
+		isCanceling := vm.isCanceling()
+
+		if isCanceling {
+			vm.setConnectionStatus(Disconnected)
+		} else {
+			vm.device.SetDestination(specs, ProvideModePublic)
+			vm.setSelectedLocation(location)
+			vm.setConnectedProviderCount(location.ProviderCount)
+			vm.setConnectionStatus(Connected)
+		}
+	}
+}
+
+func (vm *ConnectViewModel) ConnectBestAvailable() {
+
+	vm.setConnectionStatus(Connecting)
+
+	specs := &ProviderSpecList{}
+	specs.Add(&ProviderSpec{
+		BestAvailable: true,
+	})
+
+	args := &FindProviders2Args{
+		Specs: specs,
+		Count: 1024,
+	}
+
+	vm.device.Api().FindProviders2(args, FindProviders2Callback(newApiCallback[*FindProviders2Result](
+		func(result *FindProviders2Result, err error) {
+
+			isCanceling := vm.isCanceling()
+			if isCanceling {
+				vm.setConnectionStatus(Disconnected)
+			} else {
+
+				if err != nil && result.ProviderStats != nil {
+
+					clientIds := []Id{}
+					for _, provider := range result.ProviderStats.exportedList.values {
+						clientId := provider.ClientId
+						clientIds = append(clientIds, *clientId)
+					}
+					vm.setConnectedProviderCount(int32(len(clientIds)))
+					vm.setConnectionStatus(Connected)
+				} else {
+					vm.setConnectionStatus(Disconnected)
+				}
+			}
+		},
+	)))
+}
+
+func (vm *ConnectViewModel) CancelConnection() {
+	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
+	status := Canceling
+	vm.connectionStatus = status
+	vm.connectionStatusChanged()
+}
+
+// func (self *ConnectViewController) Shuffle() {
+// 	self.device.Shuffle()
+// }
+
+// func (self *ConnectViewController) Broaden() {
+// 	// FIXME
+// 	var upLocation *ConnectLocation
+// 	func() {
+// 		self.stateLock.Lock()
+// 		defer self.stateLock.Unlock()
+
+// 		if self.selectedLocation != nil {
+// 			if !self.selectedLocation.IsGroup() {
+// 				// a location
+// 				switch self.selectedLocation.LocationType {
+// 				case LocationTypeCity:
+// 					upLocation = self.selectedLocation.ToRegion()
+// 				case LocationTypeRegion:
+// 					upLocation = self.selectedLocation.ToCountry()
+// 					// TODO Mark each country with an upgroup
+// 					// case Country:
+// 					// 	upLocation = self.activeLocation.UpGroup()
+// 				}
+// 			}
+// 		}
+// 	}()
+
+// 	if upLocation != nil {
+// 		self.Connect(upLocation)
+// 	}
+// }
+
+// func (self *ConnectViewController) Reset() {
+// 	// self.device.client().Reset()
+
+// 	// todo how to reset?
+// }
+
+func (vm *ConnectViewModel) Disconnect() {
+	vm.device.RemoveDestination()
+	vm.connectionStatus = Disconnected
+	vm.connectionStatusChanged()
+}
+
+// merged location and location group
+type ConnectLocation struct {
+	ConnectLocationId *ConnectLocationId
+	Name              string
+
+	ProviderCount int32
+	Promoted      bool
+	MatchDistance int32
+
+	LocationType LocationType
+
+	City        string
+	Region      string
+	Country     string
+	CountryCode string
+
+	CityLocationId    *Id
+	RegionLocationId  *Id
+	CountryLocationId *Id
+}
+
+func (self *ConnectLocation) IsGroup() bool {
+	return self.ConnectLocationId.IsGroup()
+}
+
+func (self *ConnectLocation) IsDevice() bool {
+	return self.ConnectLocationId.IsDevice()
+}
+
+func (self *ConnectLocation) ToRegion() *ConnectLocation {
+	return &ConnectLocation{
+		ConnectLocationId: self.ConnectLocationId,
+		Name:              self.Region,
+
+		ProviderCount: self.ProviderCount,
+		Promoted:      false,
+		MatchDistance: 0,
+
+		LocationType: LocationTypeRegion,
+
+		City:        "",
+		Region:      self.Region,
+		Country:     self.Country,
+		CountryCode: self.CountryCode,
+
+		CityLocationId:    nil,
+		RegionLocationId:  self.RegionLocationId,
+		CountryLocationId: self.CountryLocationId,
+	}
+}
+
+func (self *ConnectLocation) ToCountry() *ConnectLocation {
+	return &ConnectLocation{
+		ConnectLocationId: self.ConnectLocationId,
+		Name:              self.Country,
+
+		ProviderCount: self.ProviderCount,
+		Promoted:      false,
+		MatchDistance: 0,
+
+		LocationType: LocationTypeCountry,
+
+		City:        "",
+		Region:      "",
+		Country:     self.Country,
+		CountryCode: self.CountryCode,
+
+		CityLocationId:    nil,
+		RegionLocationId:  nil,
+		CountryLocationId: self.CountryLocationId,
+	}
+}
+
+// merged location and location group
+type ConnectLocationId struct {
+	// if set, the location is a direct connection to another device
+	ClientId        *Id
+	LocationId      *Id
+	LocationGroupId *Id
+}
+
+func (self *ConnectLocationId) IsGroup() bool {
+	return self.LocationGroupId != nil
+}
+
+func (self *ConnectLocationId) IsDevice() bool {
+	return self.ClientId != nil
+}
+
+func (self *ConnectLocationId) Cmp(b *ConnectLocationId) int {
+	// - direct
+	// - group
+	if self.ClientId != nil && b.ClientId != nil {
+		if c := self.ClientId.Cmp(b.ClientId); c != 0 {
+			return c
+		}
+	} else if self.ClientId != nil {
+		return -1
+	} else if b.ClientId != nil {
+		return 1
+	}
+
+	if self.LocationGroupId != nil && b.LocationGroupId != nil {
+		if c := self.LocationGroupId.Cmp(b.LocationGroupId); c != 0 {
+			return c
+		}
+	} else if self.LocationGroupId != nil {
+		return -1
+	} else if b.LocationGroupId != nil {
+		return 1
+	}
+
+	if self.LocationId != nil && b.LocationId != nil {
+		if c := self.LocationId.Cmp(b.LocationId); c != 0 {
+			return c
+		}
+	} else if self.LocationId != nil {
+		return -1
+	} else if b.LocationId != nil {
+		return 1
+	}
+
+	return 0
+}

--- a/client/device.go
+++ b/client/device.go
@@ -453,6 +453,18 @@ func (self *BringYourDevice) OpenConnectViewController() *ConnectViewController 
 	return vc
 }
 
+func (self *BringYourDevice) OpenLocationsViewModel() *LocationsViewModel {
+	vm := newLocationsViewModel(self.ctx, self)
+	self.openViewController(vm)
+	return vm
+}
+
+func (self *BringYourDevice) OpenConnectViewModel() *ConnectViewModel {
+	vm := newConnectViewModel(self.ctx, self)
+	self.openViewController(vm)
+	return vm
+}
+
 func (self *BringYourDevice) OpenProvideViewController() *ProvideViewController {
 	vc := newProvideViewController(self.ctx, self)
 	self.openViewController(vc)

--- a/client/locations_view_model.go
+++ b/client/locations_view_model.go
@@ -1,0 +1,361 @@
+package client
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+
+	"bringyour.com/connect"
+)
+
+var lvmLog = logFn("locations_view_model")
+
+type FilteredLocationsListener interface {
+	FilteredLocationsChanged()
+}
+
+type LocationsViewModel struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	device *BringYourDevice
+
+	stateLock sync.Mutex
+
+	locations                    *ConnectLocationList
+	nextFilterSequenceNumber     int64
+	previousFilterSequenceNumber int64
+
+	filteredLocationListeners *connect.CallbackList[FilteredLocationsListener]
+}
+
+func newLocationsViewModel(ctx context.Context, device *BringYourDevice) *LocationsViewModel {
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	vm := &LocationsViewModel{
+		ctx:    cancelCtx,
+		cancel: cancel,
+		device: device,
+
+		nextFilterSequenceNumber:     0,
+		previousFilterSequenceNumber: 0,
+		locations:                    NewConnectLocationList(),
+
+		filteredLocationListeners: connect.NewCallbackList[FilteredLocationsListener](),
+	}
+	return vm
+}
+
+func (vm *LocationsViewModel) Start() {
+	vm.FilterLocations("")
+}
+
+func (vm *LocationsViewModel) Stop() {}
+
+func (vm *LocationsViewModel) Close() {
+	lvmLog("close")
+
+	vm.cancel()
+}
+
+func (vm *LocationsViewModel) GetLocations() *ConnectLocationList {
+	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
+	return vm.locations
+}
+
+func (vm *LocationsViewModel) filteredLocationsChanged() {
+	for _, listener := range vm.filteredLocationListeners.Get() {
+		connect.HandleError(func() {
+			listener.FilteredLocationsChanged()
+		})
+	}
+}
+
+func (vm *LocationsViewModel) AddFilteredLocationsListener(listener FilteredLocationsListener) Sub {
+	callbackId := vm.filteredLocationListeners.Add(listener)
+	return newSub(func() {
+		vm.filteredLocationListeners.Remove(callbackId)
+	})
+}
+
+func (vm *LocationsViewModel) FilterLocations(filter string) {
+	// api call, call callback
+	filter = strings.TrimSpace(filter)
+
+	lvmLog("FILTER LOCATIONS %s", filter)
+
+	var filterSequenceNumber int64
+	vm.stateLock.Lock()
+	vm.nextFilterSequenceNumber += 1
+	filterSequenceNumber = vm.nextFilterSequenceNumber
+	vm.stateLock.Unlock()
+
+	lvmLog("POST FILTER LOCATIONS %s", filter)
+
+	if filter == "" {
+		vm.device.Api().GetProviderLocations(FindLocationsCallback(newApiCallback[*FindLocationsResult](
+			func(result *FindLocationsResult, err error) {
+				lvmLog("FIND LOCATIONS RESULT %s %s", result, err)
+				if err == nil {
+					var update bool
+					vm.stateLock.Lock()
+					if vm.previousFilterSequenceNumber < filterSequenceNumber {
+						vm.previousFilterSequenceNumber = filterSequenceNumber
+						update = true
+					}
+					vm.stateLock.Unlock()
+
+					if update {
+						vm.setFilteredLocationsFromResult(result)
+					}
+				}
+			},
+		)))
+	} else {
+		findLocations := &FindLocationsArgs{
+			Query: filter,
+		}
+		vm.device.Api().FindProviderLocations(findLocations, FindLocationsCallback(newApiCallback[*FindLocationsResult](
+			func(result *FindLocationsResult, err error) {
+				lvmLog("FIND LOCATIONS RESULT %s %s", result, err)
+				if err == nil {
+					var update bool
+					vm.stateLock.Lock()
+					if vm.previousFilterSequenceNumber < filterSequenceNumber {
+						vm.previousFilterSequenceNumber = filterSequenceNumber
+						update = true
+					}
+					vm.stateLock.Unlock()
+
+					if update {
+						vm.setFilteredLocationsFromResult(result)
+					}
+				}
+			},
+		)))
+	}
+}
+
+func (vm *LocationsViewModel) setFilteredLocationsFromResult(result *FindLocationsResult) {
+	lvmLog("SET FILTERED LOCATIONS FROM RESULT %s", result)
+
+	locations := []*ConnectLocation{}
+
+	for i := 0; i < result.Groups.Len(); i += 1 {
+		groupResult := result.Groups.Get(i)
+
+		location := &ConnectLocation{
+			ConnectLocationId: &ConnectLocationId{
+				LocationGroupId: groupResult.LocationGroupId,
+			},
+			Name:          groupResult.Name,
+			ProviderCount: int32(groupResult.ProviderCount),
+			Promoted:      groupResult.Promoted,
+			MatchDistance: int32(groupResult.MatchDistance),
+		}
+		locations = append(locations, location)
+	}
+
+	for i := 0; i < result.Locations.Len(); i += 1 {
+		locationResult := result.Locations.Get(i)
+
+		location := &ConnectLocation{
+			ConnectLocationId: &ConnectLocationId{
+				LocationId: locationResult.LocationId,
+			},
+			LocationType:      locationResult.LocationType,
+			Name:              locationResult.Name,
+			City:              locationResult.City,
+			Region:            locationResult.Region,
+			Country:           locationResult.Country,
+			CountryCode:       locationResult.CountryCode,
+			CityLocationId:    locationResult.CityLocationId,
+			RegionLocationId:  locationResult.RegionLocationId,
+			CountryLocationId: locationResult.CountryLocationId,
+			ProviderCount:     int32(locationResult.ProviderCount),
+			MatchDistance:     int32(locationResult.MatchDistance),
+		}
+		locations = append(locations, location)
+	}
+
+	for i := 0; i < result.Devices.Len(); i += 1 {
+		locationDeviceResult := result.Devices.Get(i)
+
+		location := &ConnectLocation{
+			ConnectLocationId: &ConnectLocationId{
+				ClientId: locationDeviceResult.ClientId,
+			},
+			Name: locationDeviceResult.DeviceName,
+		}
+		locations = append(locations, location)
+	}
+
+	slices.SortStableFunc(locations, cmpConnectLocations)
+
+	exportedFilteredLocations := NewConnectLocationList()
+	exportedFilteredLocations.addAll(locations...)
+	vm.locations = exportedFilteredLocations
+	vm.filteredLocationsChanged()
+}
+
+func cmpConnectLocations(a *ConnectLocation, b *ConnectLocation) int {
+	// sort locations
+	// - provider count descending
+	// - name
+
+	if a == b {
+		return 0
+	}
+
+	// provider count descending
+	if a.ProviderCount != b.ProviderCount {
+		if a.ProviderCount < b.ProviderCount {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	if a.Name != b.Name {
+		if a.Name < b.Name {
+			return -1
+		} else {
+			return 1
+		}
+	}
+
+	return a.ConnectLocationId.Cmp(b.ConnectLocationId)
+
+}
+
+/**
+ * Code is usually the country code which maps to a color hex.
+ * If the location is not a country, we just need a unique string that represents the location
+ * ie locationId.toString()
+ */
+func (vm *LocationsViewModel) GetColorHex(code string) string {
+
+	if color, exists := countryCodeColorHexes[code]; exists {
+		return color
+	}
+
+	/**
+	 * Fallback if color hex isn't found, generate a new one by mixing two colors together
+	 */
+	keys := make([]string, 0, len(countryCodeColorHexes))
+	for k := range countryCodeColorHexes {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	index1 := getHashIndex(code, len(keys))
+	index2 := getHashIndex(code+"salt", len(keys))
+
+	color1 := countryCodeColorHexes[keys[index1]]
+	color2 := countryCodeColorHexes[keys[index2]]
+
+	return mixColors(color1, color2)
+}
+
+// to get a consistent index from the id
+func getHashIndex(id string, mod int) int {
+	hash := md5.Sum([]byte(id))
+	return int(hash[0]) % mod
+}
+
+func mixColors(color1, color2 string) string {
+	r1, g1, b1 := hexToRGB(color1)
+	r2, g2, b2 := hexToRGB(color2)
+
+	// Mix the colors by averaging their RGB components
+	r := (r1 + r2) / 2
+	g := (g1 + g2) / 2
+	b := (b1 + b2) / 2
+
+	return rgbToHex(r, g, b)
+}
+
+func hexToRGB(hex string) (int, int, int) {
+	var r, g, b int
+	fmt.Sscanf(hex, "%02x%02x%02x", &r, &g, &b)
+	return r, g, b
+}
+
+func rgbToHex(r, g, b int) string {
+	return fmt.Sprintf("%02x%02x%02x", r, g, b)
+}
+
+var countryCodeColorHexes = map[string]string{
+	"is": "639A88",
+	"ee": "78C0E0",
+	"ca": "449DD1",
+	"de": "663F46",
+	"au": "F29E4C",
+	"us": "BAC5B3",
+	"gb": "F1789B",
+	"jp": "CC3363",
+	"ie": "7EE081",
+	"fi": "F56E48",
+	"nl": "F56E48",
+	"se": "A4C4F4",
+	"fr": "A864DC",
+	"it": "F9F871",
+	"dk": "D6E6F4",
+	"no": "BCE5DC",
+	"be": "9B4A91",
+	"at": "FFCB68",
+	"ch": "FFABA0",
+	"nz": "008A64",
+	"pt": "248C89",
+	"es": "B41F43",
+	"lv": "EEE8A9",
+	"lt": "8179E0",
+	"cz": "99E8CE",
+	"si": "FF6C58",
+	"sk": "87FB67",
+	"pl": "D38B5D",
+	"hu": "FF8484",
+	"hr": "99B2DD",
+	"ro": "C6362F",
+	"bg": "A1CDF4",
+	"gr": "C874D9",
+	"cy": "E1BBC9",
+	"mt": "FFC43D",
+	"il": "A9E4EF",
+	"za": "F2B79F",
+	"ar": "8E8DBE",
+	"br": "DCD6F7",
+	"cl": "FA824C",
+	"cr": "E07A5F",
+	"uy": "7FDEFF",
+	"jm": "7B886F",
+	"tt": "0072BB",
+	"gh": "1098F7",
+	"ke": "F2EDEB",
+	"ng": "64113F",
+	"tn": "6B4D57",
+	"sn": "596869",
+	"na": "813405",
+	"bw": "D45113",
+	"mu": "60E1E0",
+	"mg": "F25D72",
+	"in": "F2E2D2",
+	"kr": "C320D9",
+	"tw": "E6EA23",
+	"my": "3A1772",
+	"ph": "B4CEB3",
+	"id": "586189",
+	"mn": "A6A57A",
+	"ge": "679436",
+	"am": "F2B5D4",
+	"ua": "00F28D",
+	"md": "7F675B",
+	"me": "E5FFDE",
+	"rs": "FF495C",
+	"al": "E4B363",
+}


### PR DESCRIPTION
Separates out connect and locations list. 

One thing to note here, on the mobile end of things, both Jetpack Compose and SwiftUI use ViewModels. We can feed our data store into the ViewModel, and have all gomobile interactions take place inside of it. So I started naming things _view_model rather than _view_controller, but it's essentially the same thing. A data store we feed into Jetpack Compose/Swift UI ViewModels.