### PR TITLE
client fixes

### DIFF
--- a/client/account_view_controller.go
+++ b/client/account_view_controller.go
@@ -83,7 +83,7 @@ func newWalletValidateAddress(
 		monitor:     connect.NewMonitor(),
 		updateCount: 0,
 	}
-	go walletValidateAddress.run()
+	go connect.HandleError(walletValidateAddress.run)
 	return walletValidateAddress
 }
 
@@ -105,7 +105,7 @@ func (self *walletValidateAddress) run() {
 					Address: address,
 					Chain:   chain,
 				},
-				newApiCallback[*WalletValidateAddressResult](func(result *WalletValidateAddressResult, err error) {
+				connect.NewApiCallback[*WalletValidateAddressResult](func(result *WalletValidateAddressResult, err error) {
 					self.stateLock.Lock()
 					head := (updateCount == self.updateCount)
 					self.stateLock.Unlock()

--- a/client/connect_view_controller.go
+++ b/client/connect_view_controller.go
@@ -220,7 +220,7 @@ func (self *ConnectViewController) FilterLocations(filter string) {
 	cvcLog("POST FILTER LOCATIONS %s", filter)
 
 	if filter == "" {
-		self.device.Api().GetProviderLocations(FindLocationsCallback(newApiCallback[*FindLocationsResult](
+		self.device.Api().GetProviderLocations(FindLocationsCallback(connect.NewApiCallback[*FindLocationsResult](
 			func(result *FindLocationsResult, err error) {
 				cvcLog("FIND LOCATIONS RESULT %s %s", result, err)
 				if err == nil {
@@ -242,7 +242,7 @@ func (self *ConnectViewController) FilterLocations(filter string) {
 		findLocations := &FindLocationsArgs{
 			Query: filter,
 		}
-		self.device.Api().FindProviderLocations(findLocations, FindLocationsCallback(newApiCallback[*FindLocationsResult](
+		self.device.Api().FindProviderLocations(findLocations, FindLocationsCallback(connect.NewApiCallback[*FindLocationsResult](
 			func(result *FindLocationsResult, err error) {
 				cvcLog("FIND LOCATIONS RESULT %s %s", result, err)
 				if err == nil {

--- a/client/device.go
+++ b/client/device.go
@@ -13,6 +13,9 @@ import (
 	"bringyour.com/protocol"
 )
 
+// the device upgrades the api, including setting the client jwt
+// closing the device does not close the api
+
 var deviceLog = logFn("device")
 
 const DebugUseSingleClientConnect = false
@@ -49,6 +52,8 @@ func defaultDeviceSettings() *deviceSettings {
 }
 
 type BringYourDevice struct {
+	api *BringYourApi
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -90,36 +95,38 @@ type BringYourDevice struct {
 	provideChangeListeners *connect.CallbackList[ProvideChangeListener]
 	connectChangeListeners *connect.CallbackList[ConnectChangeListener]
 
-	api *BringYourApi
-
 	localUserNatUnsub func()
 }
 
 func NewBringYourDeviceWithDefaults(
+	api *BringYourApi,
 	byJwt string,
 	platformUrl string,
-	apiUrl string,
 	deviceDescription string,
 	deviceSpec string,
 	appVersion string,
 	instanceId *Id,
 ) (*BringYourDevice, error) {
-	return newBringYourDevice(
-		byJwt,
-		platformUrl,
-		apiUrl,
-		deviceDescription,
-		deviceSpec,
-		appVersion,
-		instanceId,
-		defaultDeviceSettings(),
+	return traceWithReturnError(
+		func() (*BringYourDevice, error) {
+			return newBringYourDevice(
+				api,
+				byJwt,
+				platformUrl,
+				deviceDescription,
+				deviceSpec,
+				appVersion,
+				instanceId,
+				defaultDeviceSettings(),
+			)
+		},
 	)
 }
 
 func newBringYourDevice(
+	api *BringYourApi,
 	byJwt string,
 	platformUrl string,
-	apiUrl string,
 	deviceDescription string,
 	deviceSpec string,
 	appVersion string,
@@ -131,15 +138,14 @@ func newBringYourDevice(
 		return nil, err
 	}
 
-	cancelCtx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	// ctx, cancel := api.ctx, api.cancel
+	apiUrl := api.apiUrl
+	clientStrategy := api.clientStrategy
 
-	clientStrategy := connect.NewClientStrategy(
-		cancelCtx,
-		connect.DefaultClientStrategySettings(),
-	)
-	clientOob := connect.NewApiOutOfBandControl(cancelCtx, clientStrategy, byJwt, apiUrl)
+	clientOob := connect.NewApiOutOfBandControl(ctx, clientStrategy, byJwt, apiUrl)
 	client := connect.NewClient(
-		cancelCtx,
+		ctx,
 		clientId,
 		clientOob,
 		// connect.DefaultClientSettingsNoNetworkEvents(),
@@ -172,11 +178,12 @@ func newBringYourDevice(
 	localUserNatSettings.TcpBufferSettings.UserLimit = 0
 	localUserNat := connect.NewLocalUserNat(client.Ctx(), clientId.String(), localUserNatSettings)
 
-	api := newBringYourApiWithContext(cancelCtx, apiUrl)
+	// api := newBringYourApiWithContext(cancelCtx, clientStrategy, apiUrl)
 	api.SetByJwt(byJwt)
 
 	byDevice := &BringYourDevice{
-		ctx:               cancelCtx,
+		api:               api,
+		ctx:               ctx,
 		cancel:            cancel,
 		byJwt:             byJwt,
 		platformUrl:       platformUrl,
@@ -200,7 +207,6 @@ func newBringYourDevice(
 		receiveCallbacks:                  connect.NewCallbackList[connect.ReceivePacketFunction](),
 		provideChangeListeners:            connect.NewCallbackList[ProvideChangeListener](),
 		connectChangeListeners:            connect.NewCallbackList[ConnectChangeListener](),
-		api:                               api,
 	}
 
 	// set up with nil destination

--- a/client/devices_view_controller.go
+++ b/client/devices_view_controller.go
@@ -42,7 +42,7 @@ func (self *DevicesViewController) Start() {
 	// FIXME
 
 	// request clients
-	self.device.Api().GetNetworkClients(GetNetworkClientsCallback(newApiCallback[*NetworkClientsResult](
+	self.device.Api().GetNetworkClients(GetNetworkClientsCallback(connect.NewApiCallback[*NetworkClientsResult](
 		func(result *NetworkClientsResult, err error) {
 			if err == nil {
 				// FIXME sort

--- a/client/gl_view_controller.go
+++ b/client/gl_view_controller.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"golang.org/x/mobile/gl"
+
+	"bringyour.com/connect"
 )
 
 var glvcLog = logFn("gl_view_controller")
@@ -196,11 +198,11 @@ func (self *glViewController) StartGl(callback GLViewCallback) {
 		ctx, stop := context.WithCancel(context.Background())
 		self.loopStop = &stop
 
-		go func() {
+		go connect.HandleError(func() {
 			// see https://github.com/golang/go/wiki/LockOSThread
 			runtime.LockOSThread()
 			self.drawLoop(ctx, callback)
-		}()
+		})
 	}
 }
 func (self *glViewController) StopGl() {

--- a/client/local_state.go
+++ b/client/local_state.go
@@ -230,7 +230,7 @@ func NewAsyncLocalState(localStorageHome string) *AsyncLocalState {
 		localState: localState,
 		jobs:       make(chan *job, AsyncQueueSize),
 	}
-	go asyncLocalState.run()
+	go connect.HandleError(asyncLocalState.run)
 
 	return asyncLocalState
 }

--- a/client/login_view_controller.go
+++ b/client/login_view_controller.go
@@ -107,7 +107,7 @@ func newNetworkCheck(
 		monitor:     connect.NewMonitor(),
 		updateCount: 0,
 	}
-	go networkCheck.run()
+	go connect.HandleError(networkCheck.run)
 	return networkCheck
 }
 
@@ -127,7 +127,7 @@ func (self *networkCheck) run() {
 				&NetworkCheckArgs{
 					NetworkName: networkName,
 				},
-				newApiCallback[*NetworkCheckResult](func(result *NetworkCheckResult, err error) {
+				connect.NewApiCallback[*NetworkCheckResult](func(result *NetworkCheckResult, err error) {
 					self.stateLock.Lock()
 					head := (updateCount == self.updateCount)
 					self.stateLock.Unlock()

--- a/client/trace.go
+++ b/client/trace.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"fmt"
+)
+
+func trace(callback func()) (returnErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				returnErr = err
+			} else {
+				returnErr = fmt.Errorf("%s", r)
+			}
+		}
+	}()
+	callback()
+	return
+}
+
+func traceWithError(callback func() error) (returnErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				returnErr = err
+			} else {
+				returnErr = fmt.Errorf("%s", r)
+			}
+		}
+	}()
+	returnErr = callback()
+	return
+}
+
+func traceWithReturn[R any](callback func() R) (result R, returnErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				returnErr = err
+			} else {
+				returnErr = fmt.Errorf("%s", r)
+			}
+		}
+	}()
+	result = callback()
+	return
+}
+
+func traceWithReturnError[R any](callback func() (R, error)) (result R, returnErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				returnErr = err
+			} else {
+				returnErr = fmt.Errorf("%s", r)
+			}
+		}
+	}()
+	result, returnErr = callback()
+	return
+}


### PR DESCRIPTION
- use client strategy in the api. This was a mistake to omit in the client strategy change.
- change the device to take an existing api. We want to reuse the client strategy and not recreate it.
- the client strategy is created in the api
- start a new approach to unhandled errors to log and surface them as native exceptions

Depends on https://github.com/bringyour/connect/pull/31