### PR TITLE
connect view controller: connect grid fixes

### DIFF
--- a/client/device.go
+++ b/client/device.go
@@ -287,12 +287,13 @@ func (self *BringYourDevice) GetRouteLocal() bool {
 // 	return nil
 // }
 
-func (self *BringYourDevice) addMonitorEventCallback(callback connect.MonitorEventFunction) Sub {
+func (self *BringYourDevice) windowMonitor() *connect.RemoteUserNatMultiClientMonitor {
 	switch v := self.remoteUserNatClient.(type) {
 	case *connect.RemoteUserNatMultiClient:
-		return newSub(v.Monitor().AddMonitorEventCallback(callback))
+		return v.Monitor()
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (self *BringYourDevice) AddProvideChangeListener(listener ProvideChangeListener) Sub {
@@ -695,6 +696,7 @@ func parseByJwtClientId(byJwt string) (connect.Id, error) {
 	}
 }
 
+/*
 type WindowEvents struct {
 	windowExpandEvent *connect.WindowExpandEvent
 	providerEvents    map[connect.Id]*connect.ProviderEvent
@@ -757,3 +759,4 @@ func (self *WindowEvents) EvaluationFailedClientCount() int {
 	}
 	return count
 }
+*/

--- a/client/gomobile.go
+++ b/client/gomobile.go
@@ -123,16 +123,6 @@ func NewProviderGridPointList() *ProviderGridPointList {
 	}
 }
 
-type GridPointList struct {
-	exportedList[*GridPoint]
-}
-
-func NewGridPointList() *GridPointList {
-	return &GridPointList{
-		exportedList: *newExportedList[*GridPoint](),
-	}
-}
-
 type LocationResultList struct {
 	exportedList[*LocationResult]
 }
@@ -236,22 +226,31 @@ func NewNetworkSpaceList() *NetworkSpaceList {
 // conforms to `json.Marshaler` and `json.Unmarshaler`
 type Time struct {
 	impl time.Time
+	// store this on the object to support gomobile "equals" and "hashCode"
+	TimeStr string
 }
 
 func NewTimeUnixMilli(unixMilli int64) *Time {
-	return &Time{
-		impl: time.UnixMilli(unixMilli),
-	}
+	return newTime(time.UnixMilli(unixMilli))
 }
 
 func newTime(impl time.Time) *Time {
 	return &Time{
-		impl: impl,
+		impl:    impl,
+		TimeStr: impl.String(),
 	}
+}
+
+func (self *Time) toTime() time.Time {
+	return self.impl
 }
 
 func (self *Time) UnixMilli() int64 {
 	return self.impl.UnixMilli()
+}
+
+func (self *Time) MillisUntil() int32 {
+	return int32(self.impl.Sub(time.Now()))
 }
 
 func (self *Time) Format(layout string) string {


### PR DESCRIPTION
Fix events and state related to the connect grid.

- The connect grid is created on connect, and removed on disconnect.
- Monitor event fixes.
- Terminal points linger with a transition out time (end time) before being removed.

Depends on https://github.com/bringyour/connect/pull/50