### PR TITLE
Adds network name to network user response

### DIFF
--- a/bringyour/controller/network_user_controller_test.go
+++ b/bringyour/controller/network_user_controller_test.go
@@ -80,6 +80,7 @@ func TestGetNetworkUser(t *testing.T) {
 		networkUserResult, err = GetNetworkUser(userSession)
 		assert.Equal(t, err, nil)
 		assert.Equal(t, networkUserResult.NetworkUser.UserName, updatedName)
+		assert.Equal(t, networkUserResult.NetworkUser.NetworkName, updatedNetworkName)
 
 		network := model.GetNetwork(userSession)
 		assert.Equal(t, network.NetworkId, userSession.ByJwt.NetworkId)

--- a/bringyour/model/network_user_model.go
+++ b/bringyour/model/network_user_model.go
@@ -8,11 +8,12 @@ import (
 )
 
 type NetworkUser struct {
-	UserId   bringyour.Id `json:"userId"`
-	UserName string       `json:"userName"`
-	UserAuth string       `json:"userAuth"`
-	Verified bool         `json:"verified"`
-	AuthType string       `json:"authType"`
+	UserId      bringyour.Id `json:"user_id"`
+	UserName    string       `json:"user_name"`
+	UserAuth    string       `json:"user_auth"`
+	Verified    bool         `json:"verified"`
+	AuthType    string       `json:"auth_type"`
+	NetworkName string       `json:"network_name"`
 }
 
 func GetNetworkUser(
@@ -28,12 +29,15 @@ func GetNetworkUser(
 			ctx,
 			`
 			SELECT
-				user_id,
-				user_name,
-				auth_type,
-				user_auth,
-				verified
-			FROM network_user 
+				network_user.user_id,
+				network_user.user_name,
+				network_user.auth_type,
+				network_user.user_auth,
+				network_user.verified,
+				network.network_name
+			FROM network_user
+			LEFT JOIN network ON
+				network.admin_user_id = network_user.user_id
 			WHERE user_id = $1
 		`,
 			userId,
@@ -49,6 +53,7 @@ func GetNetworkUser(
 					&networkUser.AuthType,
 					&networkUser.UserAuth,
 					&networkUser.Verified,
+					&networkUser.NetworkName,
 				))
 			}
 		})

--- a/bringyour/model/network_user_model_test.go
+++ b/bringyour/model/network_user_model_test.go
@@ -20,7 +20,9 @@ func TestNetworkUser(t *testing.T) {
 		userId := bringyour.NewId()
 		clientId := bringyour.NewId()
 
-		Testing_CreateNetwork(ctx, networkId, "a", userId)
+		networkName := "hello_world"
+
+		Testing_CreateNetwork(ctx, networkId, networkName, userId)
 
 		sourceSession := session.Testing_CreateClientSession(ctx, &jwt.ByJwt{
 			NetworkId: networkId,
@@ -36,6 +38,7 @@ func TestNetworkUser(t *testing.T) {
 		assert.Equal(t, networkUser.UserAuth, fmt.Sprintf("%s@bringyour.com", networkId))
 		assert.Equal(t, networkUser.Verified, true)
 		assert.Equal(t, networkUser.AuthType, AuthTypePassword)
+		assert.Equal(t, networkUser.NetworkName, networkName)
 
 		// update username
 		updatedName := "Lorem Ipsum"

--- a/client/api.go
+++ b/client/api.go
@@ -861,11 +861,12 @@ func (self *BringYourApi) SubscriptionCreatePaymentIdSync(createPaymentId *Subsc
 }
 
 type NetworkUser struct {
-	UserId   *Id    `json:"userId"`
-	UserName string `json:"userName"`
-	UserAuth string `json:"userAuth"`
-	Verified bool   `json:"verified"`
-	AuthType string `json:"authType"`
+	UserId      *Id    `json:"userId"`
+	UserName    string `json:"user_name"`
+	UserAuth    string `json:"user_auth"`
+	Verified    bool   `json:"verified"`
+	AuthType    string `json:"auth_type"`
+	NetworkName string `json:"network_name"`
 }
 
 type GetNetworkUserError struct {


### PR DESCRIPTION
Because network name can be updated, we can't necessarily depend on reading this from the JWT in the client, since it might be out of sync with the DB value. This adds `network_name` to the `network_user` response.