### PR TITLE
conditions for triggering network name update

### DIFF
--- a/bringyour/controller/network_user_controller.go
+++ b/bringyour/controller/network_user_controller.go
@@ -51,21 +51,26 @@ func UpdateNetworkUser(
 	clientSession *session.ClientSession,
 ) (*NetworkUserUpdateResult, error) {
 
-	// update the network name
-	result, err := model.NetworkUpdate(
-		model.NetworkUpdateArgs{NetworkName: args.NetworkName},
-		clientSession,
-	)
-	if err != nil {
-		return nil, err
-	}
+	// get the current network name
+	network := model.GetNetwork(clientSession)
 
-	if result.Error != nil {
-		return &NetworkUserUpdateResult{
-			Error: &NetworkUserUpdateError{
-				Message: result.Error.Message,
-			},
-		}, nil
+	if network.NetworkName != args.NetworkName {
+		// update the network name
+		result, err := model.NetworkUpdate(
+			model.NetworkUpdateArgs{NetworkName: args.NetworkName},
+			clientSession,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if result.Error != nil {
+			return &NetworkUserUpdateResult{
+				Error: &NetworkUserUpdateError{
+					Message: result.Error.Message,
+				},
+			}, nil
+		}
 	}
 
 	// update the network_user username

--- a/bringyour/controller/network_user_controller_test.go
+++ b/bringyour/controller/network_user_controller_test.go
@@ -22,7 +22,14 @@ func TestGetNetworkUser(t *testing.T) {
 		userId := bringyour.NewId()
 		networkName := "abcdef"
 
+		networkIdB := bringyour.NewId()
+		// clientIdB := bringyour.NewId()
+		userIdB := bringyour.NewId()
+		networkNameB := "bcdefg"
+
 		model.Testing_CreateNetwork(ctx, networkId, networkName, userId)
+
+		model.Testing_CreateNetwork(ctx, networkIdB, networkNameB, userIdB)
 
 		userSession := session.Testing_CreateClientSession(ctx, &jwt.ByJwt{
 			NetworkId: networkId,
@@ -56,7 +63,7 @@ func TestGetNetworkUser(t *testing.T) {
 
 		// should fail because network name unavailable
 		updateArgs = &NetworkUserUpdateArgs{
-			NetworkName: "abcdef",
+			NetworkName: networkNameB,
 			UserName:    updatedName,
 		}
 		updateNetworkUserResult, err = UpdateNetworkUser(updateArgs, userSession)
@@ -67,8 +74,24 @@ func TestGetNetworkUser(t *testing.T) {
 		assert.Equal(t, err, nil)
 		assert.Equal(t, networkUserResult.NetworkUser.UserName, "test")
 
-		// should pass
+		// should update only the username since network name is unchanged
+		updateArgs = &NetworkUserUpdateArgs{
+			NetworkName: networkName,
+			UserName:    updatedName,
+		}
+		updateNetworkUserResult, err = UpdateNetworkUser(updateArgs, userSession)
+		assert.Equal(t, err, nil)
+		assert.Equal(t, updateNetworkUserResult.Error, nil)
+
+		networkUserResult, err = GetNetworkUser(userSession)
+		assert.Equal(t, err, nil)
+		assert.Equal(t, networkUserResult.NetworkUser.UserName, updatedName)
+		// should be the original network name
+		assert.Equal(t, networkUserResult.NetworkUser.NetworkName, networkName)
+
+		// should update both network name && username
 		updatedNetworkName := "uvwxyz"
+		updatedName = "hello world"
 		updateArgs = &NetworkUserUpdateArgs{
 			NetworkName: updatedNetworkName,
 			UserName:    updatedName,


### PR DESCRIPTION
Only trigger network name update if args don't match current network name