### PR TITLE
bugfix: select new location while connected not updating grid

### DIFF
--- a/client/connect_view_controller.go
+++ b/client/connect_view_controller.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+
 	// "fmt"
 	"math"
 	mathrand "math/rand"
@@ -254,6 +255,11 @@ func (self *ConnectViewController) setGrid() {
 }
 
 func (self *ConnectViewController) Connect(location *ConnectLocation) {
+
+	if self.connectionStatus != Disconnected {
+		self.Disconnect()
+	}
+
 	self.setConnected(true)
 	self.setConnectionStatus(Connecting)
 


### PR DESCRIPTION
If the user is already connected, and selects a new location, first trigger a disconnect before connecting to new location.