### PR TITLE
poll wallets for newly created

### DIFF
--- a/client/wallet_view_controller.go
+++ b/client/wallet_view_controller.go
@@ -466,8 +466,10 @@ func (vc *WalletViewController) setAccountPayments(payments []*AccountPayment) {
 	func() {
 		vc.stateLock.Lock()
 		defer vc.stateLock.Unlock()
-		vc.accountPayments = NewAccountPaymentsList()
-		vc.accountPayments.addAll(payments...)
+		if len(payments) > 0 {
+			vc.accountPayments = NewAccountPaymentsList()
+			vc.accountPayments.addAll(payments...)
+		}
 	}()
 
 	vc.paymentsChanged()
@@ -480,6 +482,7 @@ func (vc *WalletViewController) fetchPayments() {
 		func(results *GetNetworkAccountPaymentsResult, err error) {
 
 			if err != nil {
+				wvcLog("fetch payments failed: %s", err.Error())
 				return
 			}
 


### PR DESCRIPTION
When a user creates a new Circle wallet, we need to poll the wallets to check for the newly created account_wallet entry