### PR TITLE
only returns payouts that have been completed

### DIFF
--- a/bringyour/model/account_payment_model.go
+++ b/bringyour/model/account_payment_model.go
@@ -1024,7 +1024,7 @@ func GetNetworkPayments(session *session.ClientSession) ([]*AccountPayment, erro
                 account_wallet.wallet_id = account_payment.wallet_id
 
             WHERE
-                network_id = $1
+                network_id = $1 AND completed = true
         `,
 			session.ByJwt.NetworkId,
 		)


### PR DESCRIPTION
For the payouts list, only show payouts that have been completed. Sometimes, payouts get stuck in states where they don't meet the minimum payout threshold, and we don't want to display that to the end user.