### PR TITLE
handles fetching network user when userAuth is nil

### DIFF
--- a/bringyour/model/network_model.go
+++ b/bringyour/model/network_model.go
@@ -603,3 +603,37 @@ func Testing_CreateNetwork(
 
 	return
 }
+
+func Testing_CreateGuestNetwork(
+	ctx context.Context,
+	networkId bringyour.Id,
+	networkName string,
+	adminUserId bringyour.Id,
+) {
+
+	bringyour.Tx(ctx, func(tx bringyour.PgTx) {
+		bringyour.RaisePgResult(tx.Exec(
+			ctx,
+			`
+				INSERT INTO network (network_id, network_name, admin_user_id)
+				VALUES ($1, $2, $3)
+			`,
+			networkId,
+			networkName,
+			adminUserId,
+		))
+
+		bringyour.RaisePgResult(tx.Exec(
+			ctx,
+			`
+				INSERT INTO network_user (user_id, user_name, auth_type, verified)
+				VALUES ($1, $2, $3, $4)
+			`,
+			adminUserId,
+			"test",
+			AuthTypeGuest,
+			false,
+		))
+	})
+
+}

--- a/bringyour/model/network_user_model.go
+++ b/bringyour/model/network_user_model.go
@@ -8,7 +8,7 @@ import (
 
 type NetworkUser struct {
 	UserId      bringyour.Id `json:"user_id"`
-	UserAuth    string       `json:"user_auth"`
+	UserAuth    *string      `json:"user_auth,omitempty"`
 	Verified    bool         `json:"verified"`
 	AuthType    string       `json:"auth_type"`
 	NetworkName string       `json:"network_name"`

--- a/bringyour/model/network_user_model_test.go
+++ b/bringyour/model/network_user_model_test.go
@@ -35,5 +35,21 @@ func TestNetworkUser(t *testing.T) {
 		networkUser = GetNetworkUser(ctx, userId)
 		assert.Equal(t, networkUser, nil)
 
+		// create guest network
+		guestNetworkId := bringyour.NewId()
+		guestUserId := bringyour.NewId()
+		guestNetworkName := "guest_hello_world"
+
+		Testing_CreateGuestNetwork(ctx, guestNetworkId, guestNetworkName, guestUserId)
+
+		networkUser = GetNetworkUser(ctx, guestUserId)
+
+		assert.NotEqual(t, networkUser, nil)
+		assert.Equal(t, networkUser.UserId, guestUserId)
+		assert.Equal(t, networkUser.UserAuth, nil)
+		assert.Equal(t, networkUser.Verified, false)
+		assert.Equal(t, networkUser.AuthType, AuthTypeGuest)
+		assert.Equal(t, networkUser.NetworkName, guestNetworkName)
+
 	})
 }

--- a/client/network_user_view_controller.go
+++ b/client/network_user_view_controller.go
@@ -32,7 +32,7 @@ type NetworkUserUpdateSuccessListener interface {
 type NetworkUser struct {
 	UserId      *Id    `json:"userId"`
 	UserName    string `json:"user_name"`
-	UserAuth    string `json:"user_auth"`
+	UserAuth    string `json:"user_auth,omitempty"`
 	Verified    bool   `json:"verified"`
 	AuthType    string `json:"auth_type"`
 	NetworkName string `json:"network_name"`


### PR DESCRIPTION
Was getting the following error when trying to fetch network user when the account is in guest mode:
```
I1019 05:08:51.079029       1 router.go:68] [h]unhandled error from route GET ^/network/user$: 
{
    "error": "pgx.ScanArgError=can't scan into dest[3]: cannot scan NULL into *string",
    "stack": [
        "goroutine 3637773 [running]:",
        "runtime/debug.Stack()",
        "runtime/debug/stack.go:26 +0x5e",
        "bringyour.com/bringyour/router.(*Router).ServeHTTP.func1.1()",
        "bringyour.com/bringyour@v0.0.0/router/router.go:71 +0xf7",
        "panic({0xf71fe0?, 0xc0081813e0?})",
        "runtime/panic.go:785 +0x132",
        "bringyour.com/bringyour.db.func1.1()",
        "bringyour.com/bringyour@v0.0.0/db.go:318 +0x2cb",
        "panic({0xf71fe0?, 0xc0081813e0?})",
        "runtime/panic.go:785 +0x132",
        "bringyour.com/bringyour.tx.func1.1()",
        "bringyour.com/bringyour@v0.0.0/db.go:440 +0x94",
        "panic({0xf71fe0?, 0xc0081813e0?})",
        "runtime/panic.go:785 +0x132",
        "bringyour.com/bringyour.tx.func1.2.1()",
        "bringyour.com/bringyour@v0.0.0/db.go:451 +0x256",
        "panic({0xf71fe0?, 0xc0081813e0?})",
        "runtime/panic.go:785 +0x132",
        "bringyour.com/bringyour.Raise(...)",
        "bringyour.com/bringyour@v0.0.0/util.go:69",
        "bringyour.com/bringyour/model.GetNetworkUser.func1.1()",
        "bringyour.com/bringyour@v0.0.0/model/network_user_model.go:50 +0x136",
```
Changes NetworkUser.UserAuth to `*string` `json:"user_auth,omitempty"`