### PR TITLE
option to create numeric 6-digit otp

### DIFF
--- a/bringyourctl/main.go
+++ b/bringyourctl/main.go
@@ -368,10 +368,12 @@ func sendAuthVerify(opts docopt.Opts) {
 
 	awsMessageSender := controller.GetAWSMessageSender()
 
+	code := model.Testing_CreateVerifyCode()
+
 	err := awsMessageSender.SendAccountMessageTemplate(
 		userAuth,
 		&controller.AuthVerifyTemplate{
-			VerifyCode: "abcdefghij",
+			VerifyCode: code,
 		},
 	)
 	if err != nil {

--- a/controller/auth_controller.go
+++ b/controller/auth_controller.go
@@ -51,7 +51,8 @@ func AuthLoginWithPassword(
 }
 
 type AuthVerifySendArgs struct {
-	UserAuth string `json:"user_auth"`
+	UserAuth   string `json:"user_auth"`
+	UseNumeric bool   `json:"use_numeric,omitempty"`
 }
 
 type AuthVerifySendResult struct {
@@ -64,8 +65,14 @@ func AuthVerifySend(
 ) (*AuthVerifySendResult, error) {
 	userAuth, _ := model.NormalUserAuthV1(&verifySend.UserAuth)
 
+	verifyCodeType := model.VerifyCodeDefault
+	if verifySend.UseNumeric {
+		verifyCodeType = model.VerifyCodeNumeric
+	}
+
 	verifyCreateCode := model.AuthVerifyCreateCodeArgs{
 		UserAuth: *userAuth,
+		CodeType: verifyCodeType,
 	}
 	verifyCreateCodeResult, err := model.AuthVerifyCreateCode(verifyCreateCode, session)
 	if err != nil {

--- a/controller/network_controller.go
+++ b/controller/network_controller.go
@@ -24,10 +24,17 @@ func NetworkCreate(
 
 	AddRefreshTransferBalance(session.Ctx, result.Network.NetworkId)
 
+	verifyUseNumeric := false
+
+	if networkCreate.VerifyUseNumeric {
+		verifyUseNumeric = true
+	}
+
 	// if verification required, send it
 	if result.VerificationRequired != nil {
 		verifySend := AuthVerifySendArgs{
-			UserAuth: result.VerificationRequired.UserAuth,
+			UserAuth:   result.VerificationRequired.UserAuth,
+			UseNumeric: verifyUseNumeric,
 		}
 		AuthVerifySend(verifySend, session)
 	} else {

--- a/model/auth_model.go
+++ b/model/auth_model.go
@@ -203,18 +203,6 @@ func AuthLogin(
 ) (*AuthLoginResult, error) {
 	userAuth, _ := NormalUserAuthV1(login.UserAuth)
 
-	if login.AuthJwt != nil {
-		server.Logger().Printf("login JWT %s\n", *login.AuthJwt)
-	} else {
-		server.Logger().Printf("login JWT is nil")
-	}
-
-	if login.AuthJwtType != nil {
-		server.Logger().Printf("login JWT type %s\n", *login.AuthJwtType)
-	} else {
-		server.Logger().Printf("login JWT type is nil")
-	}
-
 	userAuthAttemptId, allow := UserAuthAttempt(userAuth, session)
 	if !allow {
 		return nil, maxUserAuthAttemptsError()

--- a/model/auth_model.go
+++ b/model/auth_model.go
@@ -583,6 +583,7 @@ func AuthVerify(
 
 type AuthVerifyCreateCodeArgs struct {
 	UserAuth string `json:"user_auth"`
+	CodeType VerifyCodeType
 }
 
 type AuthVerifyCreateCodeResult struct {
@@ -647,7 +648,7 @@ func AuthVerifyCreateCode(
 
 		created = true
 		userAuthVerifyId := server.NewId()
-		verifyCode = createVerifyCode()
+		verifyCode = createVerifyCode(verifyCreateCode.CodeType)
 		server.RaisePgResult(tx.Exec(
 			session.Ctx,
 			`

--- a/model/auth_model_identity.go
+++ b/model/auth_model_identity.go
@@ -3,6 +3,8 @@ package model
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"math/big"
 	"net/mail"
 	"strings"
 
@@ -88,17 +90,34 @@ func createPasswordSalt() []byte {
 	return passwordSalt
 }
 
-func createVerifyCode() string {
-	verifyCode := make([]byte, 4)
-	_, err := rand.Read(verifyCode)
-	if err != nil {
-		panic(err)
+type VerifyCodeType int
+
+const (
+	VerifyCodeDefault VerifyCodeType = iota
+	VerifyCodeNumeric
+)
+
+func createVerifyCode(verifyCodeType VerifyCodeType) string {
+
+	if verifyCodeType == VerifyCodeNumeric {
+		max := big.NewInt(1000000) // 10^6
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic(err)
+		}
+		return fmt.Sprintf("%06d", n.Int64())
+	} else {
+		verifyCode := make([]byte, 4)
+		_, err := rand.Read(verifyCode)
+		if err != nil {
+			panic(err)
+		}
+		return strings.ToLower(hex.EncodeToString(verifyCode))
 	}
-	return strings.ToLower(hex.EncodeToString(verifyCode))
 }
 
 func Testing_CreateVerifyCode() string {
-	return createVerifyCode()
+	return createVerifyCode(VerifyCodeNumeric)
 }
 
 func createResetCode() string {

--- a/model/auth_model_identity.go
+++ b/model/auth_model_identity.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"math/big"
+	mathrand "math/rand"
 	"net/mail"
 	"strings"
 
@@ -100,12 +100,8 @@ const (
 func createVerifyCode(verifyCodeType VerifyCodeType) string {
 
 	if verifyCodeType == VerifyCodeNumeric {
-		max := big.NewInt(1000000) // 10^6
-		n, err := rand.Int(rand.Reader, max)
-		if err != nil {
-			panic(err)
-		}
-		return fmt.Sprintf("%06d", n.Int64())
+		code := mathrand.Int63n(1000000)
+		return fmt.Sprintf("%06d", code)
 	} else {
 		verifyCode := make([]byte, 4)
 		_, err := rand.Read(verifyCode)

--- a/model/network_model.go
+++ b/model/network_model.go
@@ -43,14 +43,15 @@ func NetworkCheck(check *NetworkCheckArgs, session *session.ClientSession) (*Net
 }
 
 type NetworkCreateArgs struct {
-	UserName    string  `json:"user_name"`
-	UserAuth    *string `json:"user_auth,omitempty"`
-	AuthJwt     *string `json:"auth_jwt,omitempty"`
-	AuthJwtType *string `json:"auth_jwt_type,omitempty"`
-	Password    *string `json:"password,omitempty"`
-	NetworkName string  `json:"network_name"`
-	Terms       bool    `json:"terms"`
-	GuestMode   bool    `json:"guest_mode"`
+	UserName         string  `json:"user_name"`
+	UserAuth         *string `json:"user_auth,omitempty"`
+	AuthJwt          *string `json:"auth_jwt,omitempty"`
+	AuthJwtType      *string `json:"auth_jwt_type,omitempty"`
+	Password         *string `json:"password,omitempty"`
+	NetworkName      string  `json:"network_name"`
+	Terms            bool    `json:"terms"`
+	GuestMode        bool    `json:"guest_mode"`
+	VerifyUseNumeric bool    `json:"verify_use_numeric"`
 }
 
 type NetworkCreateResult struct {
@@ -61,9 +62,9 @@ type NetworkCreateResult struct {
 }
 
 type NetworkCreateResultNetwork struct {
-	ByJwt       *string      `json:"by_jwt,omitempty"`
+	ByJwt       *string   `json:"by_jwt,omitempty"`
 	NetworkId   server.Id `json:"network_id,omitempty"`
-	NetworkName string       `json:"network_name,omitempty"`
+	NetworkName string    `json:"network_name,omitempty"`
 }
 
 type NetworkCreateResultVerification struct {
@@ -530,7 +531,7 @@ func NetworkUpdate(
 
 type Network struct {
 	NetworkId   *server.Id `json:"network_id"`
-	NetworkName string        `json:"network_name"`
+	NetworkName string     `json:"network_name"`
 	AdminUserId *server.Id `json:"admin_user_id"`
 }
 


### PR DESCRIPTION
Adds option for numeric 6-digit OTP. This allows for iOS to prompt autofill when the otp is saved to clipboard.
Related PRs: 
Connect: https://github.com/urnetwork/connect/pull/66
SDK: https://github.com/urnetwork/sdk/pull/8