### PR TITLE
Find providers rand fix

### DIFF
--- a/model/network_client_location_model.go
+++ b/model/network_client_location_model.go
@@ -2073,7 +2073,7 @@ func FindProviders2(
 	}
 
 	clientIds := maps.Keys(clientScores)
-	mathrand.Shuffle(len(clientIds), func(i, j) {
+	mathrand.Shuffle(len(clientIds), func(i int, j int) {
 		clientIds[i], clientIds[j] = clientIds[j], clientIds[i]
 	})
 

--- a/model/network_client_location_model_test.go
+++ b/model/network_client_location_model_test.go
@@ -262,7 +262,8 @@ func TestFindProviders2WithExclude(t *testing.T) {
 			connectionId := ConnectNetworkClient(
 				ctx,
 				clientId,
-				"0.0.0.0:0",
+				// use a unique ip per connection
+				fmt.Sprintf("0.0.0.%d:0", i),
 				handlerId,
 			)
 


### PR DESCRIPTION
Providers should be selected unformly per client address hash. The previous implementation allowed client address hashes with more providers to be selected more frequently, due to an initial sort by the priority. The selection per ip hash was a poisson rv but this fix fixes it to be uniform.