### PR TITLE
otp type param for login if verification required

### DIFF
--- a/controller/auth_controller.go
+++ b/controller/auth_controller.go
@@ -42,8 +42,16 @@ func AuthLoginWithPassword(
 	result, err := model.AuthLoginWithPassword(loginWithPassword, session)
 	// if verification required, send it
 	if result != nil && result.VerificationRequired != nil {
+
+		useNumeric := false
+
+		if loginWithPassword.VerifyOtpNumeric {
+			useNumeric = true
+		}
+
 		verifySend := AuthVerifySendArgs{
-			UserAuth: result.VerificationRequired.UserAuth,
+			UserAuth:   result.VerificationRequired.UserAuth,
+			UseNumeric: useNumeric,
 		}
 		AuthVerifySend(verifySend, session)
 	}

--- a/model/auth_model.go
+++ b/model/auth_model.go
@@ -322,8 +322,9 @@ func AuthLogin(
 }
 
 type AuthLoginWithPasswordArgs struct {
-	UserAuth string `json:"user_auth"`
-	Password string `json:"password"`
+	UserAuth         string `json:"user_auth"`
+	Password         string `json:"password"`
+	VerifyOtpNumeric bool   `json:"verify_otp_numeric,omitempty"`
 }
 
 type AuthLoginWithPasswordResult struct {


### PR DESCRIPTION
Allows for an optional param to send a numeric OTP when logging in, if user is still not verified.