### PR TITLE
adds guest_upgrade_network_id for guests merging existing account

### DIFF
--- a/api/handlers/network_user_handlers.go
+++ b/api/handlers/network_user_handlers.go
@@ -14,3 +14,7 @@ func GetNetworkUser(w http.ResponseWriter, r *http.Request) {
 func UpgradeGuest(w http.ResponseWriter, r *http.Request) {
 	router.WrapWithInputRequireAuth(controller.UpgradeFromGuest, w, r)
 }
+
+func UpgradeGuestExisting(w http.ResponseWriter, r *http.Request) {
+	router.WrapWithInputRequireAuth(controller.UpgradeFromGuestExisting, w, r)
+}

--- a/api/main.go
+++ b/api/main.go
@@ -64,6 +64,7 @@ Options:
 		router.NewRoute("POST", "/auth/code-create", handlers.AuthCodeCreate),
 		router.NewRoute("POST", "/auth/code-login", handlers.AuthCodeLogin),
 		router.NewRoute("POST", "/auth/upgrade-guest", handlers.UpgradeGuest),
+		router.NewRoute("POST", "/auth/upgrade-guest-existing", handlers.UpgradeGuestExisting),
 		router.NewRoute("POST", "/network/auth-client", handlers.AuthNetworkClient),
 		router.NewRoute("POST", "/network/remove-client", handlers.RemoveNetworkClient),
 		router.NewRoute("GET", "/network/clients", handlers.NetworkClients),

--- a/controller/network_controller.go
+++ b/controller/network_controller.go
@@ -94,6 +94,9 @@ func UpdateNetworkName(
 	return &UpdateNetworkNameResult{}, nil
 }
 
+/**
+ * Upgrades a guest to a new account
+ */
 func UpgradeFromGuest(
 	upgradeGuest model.UpgradeGuestArgs,
 	session *session.ClientSession,
@@ -121,6 +124,32 @@ func UpgradeFromGuest(
 			)
 		}
 
+	}
+
+	return result, err
+
+}
+
+/**
+ * Upgrades a guest to an existing account
+ */
+func UpgradeFromGuestExisting(
+	upgradeGuest model.UpgradeGuestExistingArgs,
+	session *session.ClientSession,
+) (*model.UpgradeGuestExistingResult, error) {
+
+	result, err := model.UpgradeFromGuestExisting(
+		upgradeGuest,
+		session,
+	)
+
+	// if verification required, send it
+	if result.VerificationRequired != nil {
+		verifySend := AuthVerifySendArgs{
+			UserAuth:   result.VerificationRequired.UserAuth,
+			UseNumeric: true,
+		}
+		AuthVerifySend(verifySend, session)
 	}
 
 	return result, err

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -1606,4 +1606,8 @@ var migrations = []any{
 	newSqlMigration(`
         ALTER TABLE network_client_location ADD COLUMN network_id uuid NULL
     `),
+
+	newSqlMigration(`
+        ALTER TABLE network ADD COLUMN guest_upgrade_network_id uuid NULL
+    `),
 }


### PR DESCRIPTION
If a user wants to upgrade their guest account to an existing authenticated account, mark the guest account with the `guest_upgrade_network_id` of the existing account.