### PR TITLE
adds network point model

### DIFF
--- a/api/handlers/account_handlers.go
+++ b/api/handlers/account_handlers.go
@@ -19,3 +19,7 @@ func GetNetworkReferralCode(w http.ResponseWriter, r *http.Request) {
 func ValidateReferralCode(w http.ResponseWriter, r *http.Request) {
 	router.WrapWithInputNoAuth(controller.ValidateReferralCode, w, r)
 }
+
+func GetNetworkPoints(w http.ResponseWriter, r *http.Request) {
+	router.WrapRequireAuth(controller.GetNetworkPoints, w, r)
+}

--- a/api/main.go
+++ b/api/main.go
@@ -115,6 +115,7 @@ Options:
 		router.NewRoute("POST", "/account/wallets/remove", handlers.RemoveWallet),
 		router.NewRoute("GET", "/account/payments", handlers.GetAccountPayments),
 		router.NewRoute("GET", "/account/referral-code", handlers.GetNetworkReferralCode),
+		router.NewRoute("GET", "/account/points", handlers.GetNetworkPoints),
 		router.NewRoute("POST", "/referral-code/validate", handlers.ValidateReferralCode),
 		router.NewRoute("GET", "/transfer/stats", handlers.TransferStats),
 		router.NewRoute("GET", "/connect", handlers.AuthConnect),

--- a/controller/network_controller.go
+++ b/controller/network_controller.go
@@ -25,11 +25,21 @@ func NetworkCreate(
 	AddRefreshTransferBalance(session.Ctx, result.Network.NetworkId)
 
 	if networkCreate.ReferralCode != nil {
-		model.CreateNetworkReferral(
+		networkReferral := model.CreateNetworkReferral(
 			session.Ctx,
 			result.Network.NetworkId,
 			*networkCreate.ReferralCode,
 		)
+
+		// note: should we check if the network subscribes before applying points?
+		if networkReferral != nil {
+			model.ApplyNetworkPoints(
+				session.Ctx,
+				*networkReferral.ReferralNetworkId,
+				"referral",
+			)
+		}
+
 	}
 
 	verifyUseNumeric := false

--- a/controller/network_controller.go
+++ b/controller/network_controller.go
@@ -25,20 +25,20 @@ func NetworkCreate(
 	AddRefreshTransferBalance(session.Ctx, result.Network.NetworkId)
 
 	if networkCreate.ReferralCode != nil {
-		networkReferral := model.CreateNetworkReferral(
+		model.CreateNetworkReferral(
 			session.Ctx,
 			result.Network.NetworkId,
 			*networkCreate.ReferralCode,
 		)
 
 		// note: should we check if the network subscribes before applying points?
-		if networkReferral != nil {
-			model.ApplyNetworkPoints(
-				session.Ctx,
-				*networkReferral.ReferralNetworkId,
-				"referral",
-			)
-		}
+		// if networkReferral != nil {
+		// 	model.ApplyNetworkPoints(
+		// 		session.Ctx,
+		// 		*networkReferral.ReferralNetworkId,
+		// 		"referral",
+		// 	)
+		// }
 
 	}
 

--- a/controller/network_controller_test.go
+++ b/controller/network_controller_test.go
@@ -48,11 +48,11 @@ func TestNetworkCreate(t *testing.T) {
 		assert.NotEqual(t, result.Network, nil)
 
 		// check referral network has points applied
-		networkPoints = model.FetchNetworkPoints(ctx, referralNetworkId)
-		assert.Equal(t, len(networkPoints), 1)
-		assert.Equal(t, networkPoints[0].NetworkId, referralNetworkId)
-		assert.Equal(t, networkPoints[0].Event, "referral")
-		assert.NotEqual(t, networkPoints[0].PointValue, 0)
+		// networkPoints = model.FetchNetworkPoints(ctx, referralNetworkId)
+		// assert.Equal(t, len(networkPoints), 1)
+		// assert.Equal(t, networkPoints[0].NetworkId, referralNetworkId)
+		// assert.Equal(t, networkPoints[0].Event, "referral")
+		// assert.NotEqual(t, networkPoints[0].PointValue, 0)
 
 		// check network referral
 		networkReferral := model.GetNetworkReferralByNetworkId(ctx, result.Network.NetworkId)

--- a/controller/network_controller_test.go
+++ b/controller/network_controller_test.go
@@ -29,6 +29,10 @@ func TestNetworkCreate(t *testing.T) {
 		userAuth := "foo@ur.io"
 		password := "bar123456789Foo!"
 
+		// check referral network has no points
+		networkPoints := model.FetchNetworkPoints(ctx, referralNetworkId)
+		assert.Equal(t, len(networkPoints), 0)
+
 		networkCreate := model.NetworkCreateArgs{
 			UserName:     "",
 			UserAuth:     &userAuth,
@@ -42,6 +46,13 @@ func TestNetworkCreate(t *testing.T) {
 		assert.Equal(t, err, nil)
 		assert.Equal(t, result.Error, nil)
 		assert.NotEqual(t, result.Network, nil)
+
+		// check referral network has points applied
+		networkPoints = model.FetchNetworkPoints(ctx, referralNetworkId)
+		assert.Equal(t, len(networkPoints), 1)
+		assert.Equal(t, networkPoints[0].NetworkId, referralNetworkId)
+		assert.Equal(t, networkPoints[0].Event, "referral")
+		assert.NotEqual(t, networkPoints[0].PointValue, 0)
 
 		// check network referral
 		networkReferral := model.GetNetworkReferralByNetworkId(ctx, result.Network.NetworkId)

--- a/controller/network_point_controller.go
+++ b/controller/network_point_controller.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"github.com/urnetwork/server/model"
+	"github.com/urnetwork/server/session"
+)
+
+type NetworkPointsResult struct {
+	NetworkPoints []model.NetworkPoint `json:"network_points"`
+}
+
+func GetNetworkPoints(
+	session *session.ClientSession,
+) (*NetworkPointsResult, error) {
+	result := model.FetchNetworkPoints(session.Ctx, session.ByJwt.NetworkId)
+
+	return &NetworkPointsResult{
+		NetworkPoints: result,
+	}, nil
+}

--- a/controller/network_point_controller_test.go
+++ b/controller/network_point_controller_test.go
@@ -35,7 +35,7 @@ func TestNetworkPoints(t *testing.T) {
 		assert.Equal(t, len(result.NetworkPoints), 0)
 
 		//  apply points
-		model.ApplyNetworkPoints(ctx, networkId, "referral")
+		model.ApplyNetworkPoints(ctx, networkId, "referral", 10)
 
 		// assert network points
 		result, err = controller.GetNetworkPoints(userSession)
@@ -46,10 +46,10 @@ func TestNetworkPoints(t *testing.T) {
 		assert.Equal(t, result.NetworkPoints[0].Event, "referral")
 		assert.NotEqual(t, result.NetworkPoints[0].PointValue, 0)
 		assert.Equal(t, result.NetworkPoints[0].CreateTime.IsZero(), false)
-		assert.NotEqual(t, result.NetworkPoints[0].PointValue, 0)
+		assert.Equal(t, result.NetworkPoints[0].PointValue, 10)
 
 		// increment
-		model.ApplyNetworkPoints(ctx, networkId, "referral")
+		model.ApplyNetworkPoints(ctx, networkId, "referral", 5)
 
 		result, err = controller.GetNetworkPoints(userSession)
 		assert.Equal(t, err, nil)

--- a/controller/network_point_controller_test.go
+++ b/controller/network_point_controller_test.go
@@ -1,0 +1,60 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/controller"
+	"github.com/urnetwork/server/jwt"
+	"github.com/urnetwork/server/model"
+	"github.com/urnetwork/server/session"
+)
+
+func TestNetworkPoints(t *testing.T) {
+	server.DefaultTestEnv().Run(func() {
+		ctx := context.Background()
+
+		networkId := server.NewId()
+		clientId := server.NewId()
+		userId := server.NewId()
+		networkName := "abcdef"
+
+		model.Testing_CreateNetwork(ctx, networkId, networkName, userId)
+
+		userSession := session.Testing_CreateClientSession(ctx, &jwt.ByJwt{
+			NetworkId: networkId,
+			ClientId:  &clientId,
+			UserId:    userId,
+		})
+
+		// assert no network points
+		result, err := controller.GetNetworkPoints(userSession)
+		assert.Equal(t, err, nil)
+		assert.Equal(t, len(result.NetworkPoints), 0)
+
+		//  apply points
+		model.ApplyNetworkPoints(ctx, networkId, "referral")
+
+		// assert network points
+		result, err = controller.GetNetworkPoints(userSession)
+		assert.Equal(t, err, nil)
+		assert.NotEqual(t, result.NetworkPoints, nil)
+		assert.Equal(t, len(result.NetworkPoints), 1)
+		assert.Equal(t, result.NetworkPoints[0].NetworkId, networkId)
+		assert.Equal(t, result.NetworkPoints[0].Event, "referral")
+		assert.NotEqual(t, result.NetworkPoints[0].PointValue, 0)
+		assert.Equal(t, result.NetworkPoints[0].CreateTime.IsZero(), false)
+		assert.NotEqual(t, result.NetworkPoints[0].PointValue, 0)
+
+		// increment
+		model.ApplyNetworkPoints(ctx, networkId, "referral")
+
+		result, err = controller.GetNetworkPoints(userSession)
+		assert.Equal(t, err, nil)
+		assert.NotEqual(t, result.NetworkPoints, nil)
+		assert.Equal(t, len(result.NetworkPoints), 2)
+
+	})
+}

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -1666,5 +1666,27 @@ var migrations = []any{
 
 	newCodeMigration(migration_20250402_ReferralCodeToAlphaNumeric),
 
-	// todo: run migration_20250402_ReferralCodeToAlphaNumeric
+	newSqlMigration(`
+        CREATE TABLE network_point_event (
+            event varchar(64) NOT NULL,
+            point_value int NOT NULL,
+
+            PRIMARY KEY (event)
+        )
+    `),
+
+	newSqlMigration(`
+        INSERT INTO network_point_event (event, point_value) 
+        VALUES ('referral', 100)
+    `),
+
+	newSqlMigration(`
+    CREATE TABLE network_point (
+        network_id uuid NOT NULL,
+        event varchar(64) NOT NULL,
+        create_time timestamp NOT NULL DEFAULT now(),
+
+        PRIMARY KEY (network_id, event, create_time)
+    )
+`),
 }

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -1667,26 +1667,13 @@ var migrations = []any{
 	newCodeMigration(migration_20250402_ReferralCodeToAlphaNumeric),
 
 	newSqlMigration(`
-        CREATE TABLE network_point_event (
+        CREATE TABLE network_point (
+            network_id uuid NOT NULL,
             event varchar(64) NOT NULL,
             point_value int NOT NULL,
+            create_time timestamp NOT NULL DEFAULT now(),
 
-            PRIMARY KEY (event)
+            PRIMARY KEY (network_id, event, create_time)
         )
     `),
-
-	newSqlMigration(`
-        INSERT INTO network_point_event (event, point_value) 
-        VALUES ('referral', 100)
-    `),
-
-	newSqlMigration(`
-    CREATE TABLE network_point (
-        network_id uuid NOT NULL,
-        event varchar(64) NOT NULL,
-        create_time timestamp NOT NULL DEFAULT now(),
-
-        PRIMARY KEY (network_id, event, create_time)
-    )
-`),
 }

--- a/model/network_point_model.go
+++ b/model/network_point_model.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/urnetwork/server"
+)
+
+type NetworkPoint struct {
+	NetworkId  server.Id `json:"network_id"`
+	Event      string    `json:"event"`
+	PointValue int       `json:"point_value"`
+	CreateTime time.Time `json:"create_time"`
+}
+
+func ApplyNetworkPoints(ctx context.Context, networkId server.Id, event string) error {
+	// Implement the logic to apply network points here
+	// This is a placeholder implementation
+
+	server.Tx(ctx, func(tx server.PgTx) {
+		server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+				INSERT INTO network_point (
+						network_id,
+						event
+				)
+				VALUES ($1, $2)
+			`,
+			networkId,
+			event,
+		))
+	})
+
+	return nil
+}
+
+func FetchNetworkPoints(ctx context.Context, networkId server.Id) (networkPoints []NetworkPoint) {
+
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+				SELECT
+						np.network_id,
+						np.event,
+						np.create_time,
+						npe.point_value
+				FROM 
+						network_point np
+				JOIN 
+						network_point_event npe ON np.event = npe.event
+				WHERE 
+						np.network_id = $1
+			`,
+			networkId,
+		)
+		server.WithPgResult(result, err, func() {
+			for result.Next() {
+
+				networkPoint := NetworkPoint{}
+				server.Raise(result.Scan(
+					&networkPoint.NetworkId,
+					&networkPoint.Event,
+					&networkPoint.CreateTime,
+					&networkPoint.PointValue,
+				))
+				networkPoints = append(networkPoints, networkPoint)
+			}
+		})
+	})
+
+	return networkPoints
+}

--- a/model/network_point_model.go
+++ b/model/network_point_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/urnetwork/server"
 )
 
@@ -61,8 +60,6 @@ func ApplyNetworkPoints(
 }
 
 func FetchNetworkPoints(ctx context.Context, networkId server.Id) (networkPoints []NetworkPoint) {
-
-	glog.Infof("Fetching network points for network ID: %s", networkId)
 
 	server.Db(ctx, func(conn server.PgConn) {
 		result, err := conn.Query(

--- a/model/network_point_model.go
+++ b/model/network_point_model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/urnetwork/server"
 )
 
@@ -60,6 +61,8 @@ func ApplyNetworkPoints(
 }
 
 func FetchNetworkPoints(ctx context.Context, networkId server.Id) (networkPoints []NetworkPoint) {
+
+	glog.Infof("Fetching network points for network ID: %s", networkId)
 
 	server.Db(ctx, func(conn server.PgConn) {
 		result, err := conn.Query(

--- a/model/network_point_model_test.go
+++ b/model/network_point_model_test.go
@@ -1,0 +1,50 @@
+package model_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/model"
+)
+
+func TestNetworkPoints(t *testing.T) {
+	server.DefaultTestEnv().Run(func() {
+
+		ctx := context.Background()
+
+		networkId := server.NewId()
+
+		// invalid point event
+
+		invalidPointEvent := "invalid_event"
+
+		err := model.ApplyNetworkPoints(ctx, networkId, invalidPointEvent)
+		assert.Equal(t, err, nil)
+
+		networkPoints := model.FetchNetworkPoints(ctx, networkId)
+		assert.Equal(t, len(networkPoints), 0)
+
+		// valid point event
+
+		pointEvent := "referral"
+
+		err = model.ApplyNetworkPoints(ctx, networkId, pointEvent)
+		assert.Equal(t, err, nil)
+
+		networkPoints = model.FetchNetworkPoints(ctx, networkId)
+		assert.NotEqual(t, networkPoints, nil)
+		assert.Equal(t, len(networkPoints), 1)
+		assert.Equal(t, networkPoints[0].NetworkId, networkId)
+		assert.Equal(t, networkPoints[0].Event, pointEvent)
+		assert.NotEqual(t, networkPoints[0].PointValue, 0)
+
+		err = model.ApplyNetworkPoints(ctx, networkId, pointEvent)
+		assert.Equal(t, err, nil)
+
+		networkPoints = model.FetchNetworkPoints(ctx, networkId)
+		assert.Equal(t, len(networkPoints), 2)
+
+	})
+}

--- a/model/network_point_model_test.go
+++ b/model/network_point_model_test.go
@@ -13,38 +13,29 @@ func TestNetworkPoints(t *testing.T) {
 	server.DefaultTestEnv().Run(func() {
 
 		ctx := context.Background()
-
 		networkId := server.NewId()
 
-		// invalid point event
-
-		invalidPointEvent := "invalid_event"
-
-		err := model.ApplyNetworkPoints(ctx, networkId, invalidPointEvent)
+		err := model.ApplyNetworkPoints(ctx, networkId, model.NetworkPointEventReferral, 10)
 		assert.Equal(t, err, nil)
 
 		networkPoints := model.FetchNetworkPoints(ctx, networkId)
-		assert.Equal(t, len(networkPoints), 0)
-
-		// valid point event
-
-		pointEvent := "referral"
-
-		err = model.ApplyNetworkPoints(ctx, networkId, pointEvent)
-		assert.Equal(t, err, nil)
-
-		networkPoints = model.FetchNetworkPoints(ctx, networkId)
 		assert.NotEqual(t, networkPoints, nil)
 		assert.Equal(t, len(networkPoints), 1)
 		assert.Equal(t, networkPoints[0].NetworkId, networkId)
-		assert.Equal(t, networkPoints[0].Event, pointEvent)
+		assert.Equal(t, networkPoints[0].Event, "referral")
 		assert.NotEqual(t, networkPoints[0].PointValue, 0)
 
-		err = model.ApplyNetworkPoints(ctx, networkId, pointEvent)
+		err = model.ApplyNetworkPoints(ctx, networkId, model.NetworkPointEventReferral, 5)
 		assert.Equal(t, err, nil)
 
 		networkPoints = model.FetchNetworkPoints(ctx, networkId)
 		assert.Equal(t, len(networkPoints), 2)
+
+		totalPoints := 0
+		for _, point := range networkPoints {
+			totalPoints += point.PointValue
+		}
+		assert.Equal(t, totalPoints, 15)
 
 	})
 }


### PR DESCRIPTION
- Adds network_point_event table, to assign events to point value. Populates "referral" event.
- Adds network_point table, which tracks individual network events
- Applies points when a network is created with a referral code