### PR TITLE
account payment: recreate payment record on failed payment

### DIFF
--- a/controller/subscription_send_payment_controller.go
+++ b/controller/subscription_send_payment_controller.go
@@ -227,9 +227,17 @@ func advancePayment(
 			// check later
 			return
 
-		case "DENIED", "FAILED", "CANCELLED":
-
+		case "DENIED", "FAILED":
 			returnErr = fmt.Errorf("[%s]error = %s", payment.PaymentId.String(), status)
+			// remove the payment record so it can be recreated
+			model.RemovePaymentRecord(
+				clientSession.Ctx,
+				payment.PaymentId,
+			)
+			return
+
+		case "CANCELLED":
+			canceled = true
 			return
 
 		case "COMPLETE":

--- a/model/account_payment_model.go
+++ b/model/account_payment_model.go
@@ -998,6 +998,31 @@ func SetPaymentRecord(
 	return
 }
 
+func RemovePaymentRecord(
+	ctx context.Context,
+	paymentId server.Id,
+) (returnErr error) {
+	server.Tx(ctx, func(tx server.PgTx) {
+		tag := server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+                UPDATE account_payment
+                SET
+                    payment_record = NULL
+                WHERE
+                    payment_id = $1 AND
+                    NOT completed AND NOT canceled
+            `,
+			paymentId,
+		))
+		if tag.RowsAffected() != 1 {
+			returnErr = fmt.Errorf("Invalid payment.")
+			return
+		}
+	})
+	return
+}
+
 func CompletePayment(ctx context.Context, paymentId server.Id, paymentReceipt string) (returnErr error) {
 	server.Tx(ctx, func(tx server.PgTx) {
 		tag := server.RaisePgResult(tx.Exec(

--- a/model/account_payment_model_test.go
+++ b/model/account_payment_model_test.go
@@ -199,7 +199,11 @@ func TestGetNetworkProvideStats(t *testing.T) {
 
 		// mark plan items as complete
 		for _, payment := range plan.NetworkPayments {
+			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
+			RemovePaymentRecord(ctx, payment.PaymentId)
+			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
+
 			CompletePayment(ctx, payment.PaymentId, "")
 		}
 
@@ -393,7 +397,11 @@ func TestPaymentPlanSubsidy(t *testing.T) {
 		subsidyPaidByteCount := paidByteCount
 
 		for _, payment := range paymentPlan.NetworkPayments {
+			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
+			RemovePaymentRecord(ctx, payment.PaymentId)
+			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
+
 			CompletePayment(ctx, payment.PaymentId, "")
 		}
 
@@ -452,7 +460,11 @@ func TestPaymentPlanSubsidy(t *testing.T) {
 		subsidyPaidByteCount = paidByteCount - subsidyPaidByteCount
 
 		for _, payment := range paymentPlan.NetworkPayments {
+			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
+			RemovePaymentRecord(ctx, payment.PaymentId)
+			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
+
 			CompletePayment(ctx, payment.PaymentId, "")
 			UpdatePaymentWallet(ctx, payment.PaymentId)
 		}


### PR DESCRIPTION
When the payment record is DENIED or FAILED, recreate the payment record. There is no way to recover from this state and may indicate an issue like insufficient balance or permission issues, which may be later fixed.