### PR TITLE
Provider split window

### DIFF
--- a/db_migrations.go
+++ b/db_migrations.go
@@ -1733,4 +1733,16 @@ var migrations = []any{
 	newSqlMigration(`
         ALTER TABLE network_point RENAME TO account_point
     `),
+
+	newSqlMigration(`
+        ALTER TABLE network_client_location
+            ADD COLUMN net_type_score_speed smallint GENERATED ALWAYS AS (
+                1 + 
+                net_type_vpn + 
+                net_type_proxy +
+                net_type_tor + 
+                net_type_relay 
+                - net_type_hosting
+            ) STORED
+    `),
 }


### PR DESCRIPTION
Find providers to support:
- Different rank modes to prioritize quality (default) or speed. Speed will prioritize the estimated byte per second and use data center ip types as a proxy for speed where the estimate is not present.
- Return the quality tier in the results. This lets the client lock in providers to a specific tier.

Depends on https://github.com/urnetwork/connect/pull/113