### PR TITLE
Populate tx_hash in account_payment

### DIFF
--- a/controller/account_payment_controller.go
+++ b/controller/account_payment_controller.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
 	// "errors"
 
 	// "sync"
@@ -273,11 +274,14 @@ func advancePayment(
 
 		case "COMPLETE":
 
+			glog.Infof("marking payment as complete with tx hash: %s", tx.TxHash)
+
 			// mark the payment complete in our DB
 			model.CompletePayment(
 				clientSession.Ctx,
 				payment.PaymentId,
-				string(txResponseBodyBytes), // STU_TODO: check this
+				string(txResponseBodyBytes),
+				tx.TxHash,
 			)
 			complete = true
 

--- a/controller/account_payment_controller.go
+++ b/controller/account_payment_controller.go
@@ -274,8 +274,6 @@ func advancePayment(
 
 		case "COMPLETE":
 
-			glog.Infof("marking payment as complete with tx hash: %s", tx.TxHash)
-
 			// mark the payment complete in our DB
 			model.CompletePayment(
 				clientSession.Ctx,

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -1794,4 +1794,8 @@ var migrations = []any{
 		ALTER TABLE account_point
 		ADD COLUMN account_payment_id uuid NULL;
 	`),
+	newSqlMigration(`
+		ALTER TABLE account_payment
+		ADD COLUMN tx_hash TEXT NULL
+	`),
 }

--- a/model/account_payment_model.go
+++ b/model/account_payment_model.go
@@ -181,11 +181,6 @@ func dbGetPayment(ctx context.Context, conn server.PgConn, paymentId server.Id) 
 				&payment.Blockchain,
 			))
 
-			if payment.TxHash != nil {
-				glog.Infof("getPayment txHash is %s", *payment.TxHash)
-			} else {
-				glog.Infof("getPayment txHash is nil")
-			}
 		}
 	})
 
@@ -1270,8 +1265,6 @@ func CompletePayment(
 	paymentReceipt string,
 	txHash string,
 ) (returnErr error) {
-
-	glog.Infof("Completing payment %s with receipt %s and tx hash %s", paymentId, paymentReceipt, txHash)
 
 	server.Tx(ctx, func(tx server.PgTx) {
 		tag := server.RaisePgResult(tx.Exec(

--- a/model/account_payment_model_test.go
+++ b/model/account_payment_model_test.go
@@ -109,6 +109,7 @@ func TestCancelAccountPayment(t *testing.T) {
 			payment, err := GetPayment(ctx, payment.PaymentId)
 			assert.Equal(t, err, nil)
 			assert.Equal(t, payment.Canceled, true)
+			assert.Equal(t, payment.Blockchain, "MATIC")
 			assert.NotEqual(t, payment.CancelTime, nil)
 		}
 

--- a/model/account_payment_model_test.go
+++ b/model/account_payment_model_test.go
@@ -205,7 +205,9 @@ func TestGetNetworkProvideStats(t *testing.T) {
 			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
 
-			CompletePayment(ctx, payment.PaymentId, "")
+			mockTxHash := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
 		transferStats = GetTransferStats(ctx, destinationNetworkId)
@@ -397,13 +399,15 @@ func TestPaymentPlanSubsidy(t *testing.T) {
 		assert.Equal(t, subsidyPayment.NetPayoutByteCountUnpaid, ByteCount(0))
 		subsidyPaidByteCount := paidByteCount
 
+		mockTxHash := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
 		for _, payment := range paymentPlan.NetworkPayments {
 			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
 			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
 
-			CompletePayment(ctx, payment.PaymentId, "")
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
 		// check that the payment is recorded
@@ -466,7 +470,7 @@ func TestPaymentPlanSubsidy(t *testing.T) {
 			RemovePaymentRecord(ctx, payment.PaymentId)
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
 
-			CompletePayment(ctx, payment.PaymentId, "")
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 			UpdatePaymentWallet(ctx, payment.PaymentId)
 		}
 

--- a/model/account_wallet_model_test.go
+++ b/model/account_wallet_model_test.go
@@ -23,7 +23,7 @@ func TestAccountWallet(t *testing.T) {
 		})
 
 		args := &CreateAccountWalletExternalArgs{
-			Blockchain:       "Polygon",
+			Blockchain:       "MATIC",
 			WalletAddress:    "0x0",
 			DefaultTokenType: "USDC",
 			NetworkId:        networkId,
@@ -108,7 +108,7 @@ func TestAccountWallet(t *testing.T) {
 		circleWalletId := server.NewId().String()
 		circleArgs := &CreateAccountWalletCircleArgs{
 			NetworkId:        networkId,
-			Blockchain:       "Polygon",
+			Blockchain:       "MATIC",
 			WalletAddress:    "0x2",
 			DefaultTokenType: "USDC",
 			CircleWalletId:   circleWalletId,

--- a/model/subscription_model_test.go
+++ b/model/subscription_model_test.go
@@ -195,6 +195,8 @@ func TestEscrow(t *testing.T) {
 		assert.Equal(t, len(paymentPlan.NetworkPayments), 0)
 		assert.Equal(t, paymentPlan.WithheldNetworkIds, []server.Id{destinationNetworkId})
 
+		mockTxHash := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
 		usedTransferByteCount = ByteCount(1024 * 1024 * 1024)
 		for paid < UsdToNanoCents(EnvSubsidyConfig().MinWalletPayoutUsd) {
 			transferEscrow, err := CreateTransferEscrow(ctx, sourceNetworkId, sourceId, destinationNetworkId, destinationId, usedTransferByteCount)
@@ -223,7 +225,7 @@ func TestEscrow(t *testing.T) {
 
 		for _, payment := range paymentPlan.NetworkPayments {
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
-			CompletePayment(ctx, payment.PaymentId, "")
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
 		// check that the payment is recorded
@@ -273,7 +275,7 @@ func TestEscrow(t *testing.T) {
 
 		for _, payment := range paymentPlan.NetworkPayments {
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
-			CompletePayment(ctx, payment.PaymentId, "")
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
 		// check that the payment is recorded
@@ -471,9 +473,11 @@ func TestCompanionEscrowAndCheckpoint(t *testing.T) {
 		assert.Equal(t, err, nil)
 		assert.Equal(t, maps.Keys(paymentPlan.NetworkPayments), []server.Id{sourceNetworkId})
 
+		mockTxHash := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
 		for _, payment := range paymentPlan.NetworkPayments {
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
-			CompletePayment(ctx, payment.PaymentId, "")
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
 		// check that the payment is recorded
@@ -538,7 +542,7 @@ func TestCompanionEscrowAndCheckpoint(t *testing.T) {
 
 		for _, payment := range paymentPlan.NetworkPayments {
 			SetPaymentRecord(ctx, payment.PaymentId, "usdc", NanoCentsToUsd(payment.Payout), "")
-			CompletePayment(ctx, payment.PaymentId, "")
+			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
 		// check that the payment is recorded


### PR DESCRIPTION
- Adds `tx_hash` column to account_payment
- Populates `blockchain` value when fetching account payments

This will let us click into specific payments to see onchain details.