### PR TITLE
network name profanity check

### DIFF
--- a/db_migrations.go
+++ b/db_migrations.go
@@ -1798,4 +1798,8 @@ var migrations = []any{
 		ALTER TABLE account_payment
 		ADD COLUMN tx_hash TEXT NULL
 	`),
+	newSqlMigration(`
+		ALTER TABLE network
+		ADD COLUMN contains_profanity BOOLEAN NOT NULL DEFAULT false
+	`),
 }

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
+	github.com/TwiN/go-away v1.6.16 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
+github.com/TwiN/go-away v1.6.16 h1:GW+ruWHuU9QCmTGxJwS8st0mGZdQ57eiJu+hWHhFVxQ=
+github.com/TwiN/go-away v1.6.16/go.mod h1:3p0vmlXrfA1kOENz6PWm+cNtJ3k5J3sp28T4DZowtYw=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/model/leaderboard_model.go
+++ b/model/leaderboard_model.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Earner struct {
-	NetworkId   string  `json:"network_id"`
-	NetworkName string  `json:"network_name"`
-	NetMiBCount float32 `json:"net_mib_count"`
-	IsPublic    bool    `json:"is_public"`
+	NetworkId         string  `json:"network_id"`
+	NetworkName       string  `json:"network_name"`
+	NetMiBCount       float32 `json:"net_mib_count"`
+	IsPublic          bool    `json:"is_public"`
+	ContainsProfanity bool    `json:"contains_profanity"` // network name contains profanity
 }
 
 type LeaderboardResult struct {
@@ -36,7 +37,8 @@ func GetLeaderboard(ctx context.Context) (earners []Earner, queryErr error) {
 						t.network_id,
 						t.net_mib_count,
 						network.network_name,
-						network.leaderboard_public
+						network.leaderboard_public,
+						network.contains_profanity
 
 				FROM (SELECT account_payment.network_id,
 										SUM(account_payment.payout_byte_count) / (1024 * 1024) AS net_mib_count
@@ -72,6 +74,7 @@ func GetLeaderboard(ctx context.Context) (earners []Earner, queryErr error) {
 					&earner.NetMiBCount,
 					&earner.NetworkName,
 					&earner.IsPublic,
+					&earner.ContainsProfanity,
 				))
 
 				if !earner.IsPublic {

--- a/model/leaderboard_model_test.go
+++ b/model/leaderboard_model_test.go
@@ -41,7 +41,7 @@ func TestLeaderboard(t *testing.T) {
 		networkIdC := server.NewId()
 		userIdC := server.NewId()
 
-		Testing_CreateNetwork(ctx, networkIdA, "a", userIdA)
+		Testing_CreateNetwork(ctx, networkIdA, "shit_contains_profanity", userIdA)
 		Testing_CreateNetwork(ctx, networkIdB, "b", userIdB)
 		Testing_CreateNetwork(ctx, networkIdC, "c", userIdC)
 		clientSessionC := session.Testing_CreateClientSession(
@@ -108,6 +108,12 @@ func TestLeaderboard(t *testing.T) {
 		assert.Equal(t, len(leaderboardStats), 2)
 		assert.Equal(t, leaderboardStats[0].NetworkId, networkIdB.String())
 		assert.Equal(t, leaderboardStats[1].NetworkId, networkIdA.String())
+
+		// profanity check
+		// network B does not contain profanity
+		assert.Equal(t, leaderboardStats[0].ContainsProfanity, false)
+		// network A contains profanity
+		assert.Equal(t, leaderboardStats[1].ContainsProfanity, true)
 
 		/**
 		 * Get individual network ranking


### PR DESCRIPTION
When creating a network, check if the network name contains profanity, and mark it accordingly.
Uses https://github.com/TwiN/go-away to check profanity.