### PR TITLE
skips caching json responses with 429 status

### DIFF
--- a/controller/network_client_location_controller.go
+++ b/controller/network_client_location_controller.go
@@ -105,11 +105,17 @@ func GetIPInfo(ctx context.Context, ipStr string) ([]byte, error) {
 		/**
 		 * Check if cached JSON is an invalid response
 		 */
+		rateLimited := false
 		if err := json.Unmarshal(resultJson, &errResp); err == nil && errResp.Status == 429 {
-			return nil, fmt.Errorf("rate limit exceeded: %s", errResp.Error.Message)
+			rateLimited = true
 		}
 
-		return resultJson, nil
+		/**
+		 * If not rate limited, return the cached response
+		 */
+		if !rateLimited {
+			return resultJson, nil
+		}
 	}
 
 	req, err := http.NewRequest(

--- a/controller/network_client_location_controller.go
+++ b/controller/network_client_location_controller.go
@@ -85,14 +85,33 @@ func GetLocationForIp(ctx context.Context, ipStr string) (*model.Location, *mode
 	return location, connectionLocationScores, nil
 }
 
+type IpInfoErrorResponse struct {
+	Status int `json:"status"`
+	Error  struct {
+		Title   string `json:"title"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
 func GetIPInfo(ctx context.Context, ipStr string) ([]byte, error) {
 	earliestResultTime := server.NowUtc().Add(-LocationLookupResultExpiration)
+
+	var errResp IpInfoErrorResponse
 
 	var resultJson []byte
 	if resultJsonStr := model.GetLatestIpLocationLookupResult(ctx, ipStr, earliestResultTime); resultJsonStr != "" {
 		resultJson = []byte(resultJsonStr)
+
+		/**
+		 * Check if cached JSON is an invalid response
+		 */
+		if err := json.Unmarshal(resultJson, &errResp); err == nil && errResp.Status == 429 {
+			return nil, fmt.Errorf("rate limit exceeded: %s", errResp.Error.Message)
+		}
+
 		return resultJson, nil
 	}
+
 	req, err := http.NewRequest(
 		"GET",
 		fmt.Sprintf("https://ipinfo.io/%s/json", ipStr),
@@ -125,6 +144,14 @@ func GetIPInfo(ctx context.Context, ipStr string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
+
+	/**
+	 * check if the response indicates a rate limit error
+	 */
+	if err := json.Unmarshal(resultJson, &errResp); err == nil && errResp.Status == 429 {
+		return nil, fmt.Errorf("rate limit exceeded: %s", errResp.Error.Message)
+	}
+
 	resultJson = server.AttemptCompactJson(resultJson)
 
 	model.SetIpLocationLookupResult(ctx, ipStr, string(resultJson))


### PR DESCRIPTION
IPInfo can return a rate limited error result:
```
{"status":429,"error":{"title":"Rate limit exceeded","message":"Upgrade to increase your usage limits at https://ipinfo.io/pricing, or contact us via https://ipinfo.io/support"}}
```
We want to avoid saving this as `result_json` in `ip_location_lookup`.
Additionally, if it's already saved, we don't want to return it, and instead refresh the call.