### PR TITLE
adds start balance and open balance bytes to subscription balance

### DIFF
--- a/controller/subscription_controller.go
+++ b/controller/subscription_controller.go
@@ -133,11 +133,21 @@ var playRefreshToken = sync.OnceValue(func() string {
 // if wallet, show a button to refresh, and to withdraw
 
 type SubscriptionBalanceResult struct {
-	BalanceByteCount          model.ByteCount          `json:"balance_byte_count"`
+	/*
+	 * StartBalanceByteCount - The available balance the user starts the day with
+	 */
+	StartBalanceByteCount model.ByteCount `json:"start_balance_byte_count"`
+	/**
+	 * BalanceByteCount - The remaining balance the user has available
+	 */
+	BalanceByteCount model.ByteCount `json:"balance_byte_count"`
+	/**
+	 * OpenTransferByteCount - The total number of bytes tied up in open transfers
+	 */
+	OpenTransferByteCount     model.ByteCount          `json:"open_transfer_byte_count"`
 	CurrentSubscription       *Subscription            `json:"current_subscription,omitempty"`
 	ActiveTransferBalances    []*model.TransferBalance `json:"active_transfer_balances,omitempty"`
 	PendingPayoutUsdNanoCents model.NanoCents          `json:"pending_payout_usd_nano_cents"`
-	WalletInfo                *CircleWalletInfo        `json:"wallet_info,omitempty"`
 	UpdateTime                time.Time                `json:"update_time"`
 }
 
@@ -151,9 +161,13 @@ func SubscriptionBalance(session *session.ClientSession) (*SubscriptionBalanceRe
 	transferBalances := model.GetActiveTransferBalances(session.Ctx, session.ByJwt.NetworkId)
 
 	netBalanceByteCount := model.ByteCount(0)
+	startBalanceByteCount := model.ByteCount(0)
 	for _, transferBalance := range transferBalances {
 		netBalanceByteCount += transferBalance.BalanceByteCount
+		startBalanceByteCount += transferBalance.StartBalanceByteCount
 	}
+
+	openTransferByteCount := model.GetOpenTransferByteCount(session.Ctx, session.ByJwt.NetworkId)
 
 	var currentSubscription *Subscription
 	if model.HasSubscriptionRenewal(session.Ctx, session.ByJwt.NetworkId, model.SubscriptionTypeSupporter) {
@@ -165,16 +179,13 @@ func SubscriptionBalance(session *session.ClientSession) (*SubscriptionBalanceRe
 	// FIXME
 	pendingPayout := model.ByteCount(0)
 
-	// ignore any error with circle,
-	// since the model won't allow the wallet to enter a corrupt state
-	walletInfo, _ := findMostRecentCircleWallet(session)
-
 	return &SubscriptionBalanceResult{
 		BalanceByteCount:          netBalanceByteCount,
+		StartBalanceByteCount:     startBalanceByteCount,
+		OpenTransferByteCount:     openTransferByteCount,
 		CurrentSubscription:       currentSubscription,
 		ActiveTransferBalances:    transferBalances,
 		PendingPayoutUsdNanoCents: pendingPayout,
-		WalletInfo:                walletInfo,
 		UpdateTime:                server.NowUtc(),
 	}, nil
 }

--- a/model/subscription_model.go
+++ b/model/subscription_model.go
@@ -2717,7 +2717,7 @@ func RemoveCompletedContracts(ctx context.Context, minTime time.Time) {
 
 func GetOpenTransferByteCount(
 	ctx context.Context,
-	sourceNetworkId server.Id,
+	payerNetworkId server.Id,
 ) ByteCount {
 
 	var openTransferByteCount ByteCount = 0
@@ -2731,10 +2731,10 @@ func GetOpenTransferByteCount(
 			   COALESCE(SUM(transfer_byte_count), 0)
 			FROM transfer_contract
 			WHERE
-			    source_network_id = $1 AND
+			    payer_network_id = $1 AND
 			    open = TRUE
 			`,
-			sourceNetworkId,
+			payerNetworkId,
 		)
 		server.WithPgResult(result, err, func() {
 			if result.Next() {

--- a/model/subscription_model_test.go
+++ b/model/subscription_model_test.go
@@ -1280,6 +1280,9 @@ func TestGetOpenTransferByteCount(t *testing.T) {
 		paidByteCount := ByteCount(0)
 		usedTransferByteCount := ByteCount(1024 * 1024 * 1024)
 
+		sourceOpenTransferByteCount := GetOpenTransferByteCount(sourceSession.Ctx, sourceNetworkId)
+		assert.Equal(t, sourceOpenTransferByteCount, ByteCount(0))
+
 		for paid < UsdToNanoCents(EnvSubsidyConfig().MinWalletPayoutUsd) {
 
 			companionTransferEscrow, err := CreateTransferEscrow(ctx, sourceNetworkId, sourceId, destinationNetworkId, destinationId, usedTransferByteCount)
@@ -1288,7 +1291,9 @@ func TestGetOpenTransferByteCount(t *testing.T) {
 			assert.Equal(t, err, nil)
 
 			sourceOpenTransferByteCount := GetOpenTransferByteCount(sourceSession.Ctx, sourceNetworkId)
-			assert.Equal(t, sourceOpenTransferByteCount, usedTransferByteCount)
+
+			// x2 since data is tied up in transfer escrow and companion transfer escrow
+			assert.Equal(t, sourceOpenTransferByteCount, usedTransferByteCount*2)
 
 			err = CloseContract(ctx, transferEscrow.ContractId, sourceId, usedTransferByteCount, false)
 			assert.Equal(t, err, nil)


### PR DESCRIPTION
Adds `StartBalanceByteCount` and `OpenTransferByteCount` to `SubscriptionBalanceResult`. We can use these to show daily usage.