### PR TITLE
Client reliability data

### DIFF
--- a/connect/transport.go
+++ b/connect/transport.go
@@ -300,6 +300,7 @@ func (self *ConnectHandler) Connect(w http.ResponseWriter, r *http.Request) {
 		announce := NewConnectionAnnounce(
 			handleCtx,
 			handleCancel,
+			byJwt.NetworkId,
 			clientId,
 			clientAddress,
 			self.handlerId,

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -628,6 +628,7 @@ func (self *ConnectHandler) connectQuic(conn *quic.Conn) error {
 		announce := NewConnectionAnnounce(
 			handleCtx,
 			handleCancel,
+			byJwt.NetworkId,
 			clientId,
 			clientAddress,
 			self.handlerId,

--- a/connect/transport_announce.go
+++ b/connect/transport_announce.go
@@ -160,7 +160,7 @@ func (self *ConnectionAnnounce) run() {
 			self.sendByteCount = 0
 		}()
 
-		stats := &ConnectionReliabilityStats{
+		stats := &model.ConnectionReliabilityStats{
 			ReceiveMessageCount: receiveMessageCount,
 			ReceiveByteCount:    receiveByteCount,
 			SendMessageCount:    sendMessageCount,
@@ -168,7 +168,7 @@ func (self *ConnectionAnnounce) run() {
 		}
 
 		if established {
-			changeCount, currentProvideModes := model.GetProvideKeyChanges(self.ctx, statsStartTime)
+			changedCount, currentProvideModes := model.GetProvideKeyChanges(self.ctx, self.clientId, statsStartTime)
 
 			// add reliability stats if all of:
 			// 1. established provide public (no changes in block)
@@ -179,22 +179,22 @@ func (self *ConnectionAnnounce) run() {
 			// OR
 			// 1. provide change (this will invalidate the block)
 
-			stats.EstablishedConnectionCount = 1
-			if currentProvideModes[ProvideModePublic] {
+			stats.ConnectionEstablishedCount = 1
+			if currentProvideModes[model.ProvideModePublic] {
 				stats.ProvideEnabledCount = 1
 			}
-			if 0 < changeCount {
-				stats.ProvideChangeCount = 1
+			if 0 < changedCount {
+				stats.ProvideChangedCount = 1
 			}
 		} else {
 			established = true
-			stats.NewConnectionCount = 1
+			stats.ConnectionNewCount = 1
 		}
-		AddConnectionReliabilityStats(
+		model.AddConnectionReliabilityStats(
 			self.ctx,
 			self.networkId,
 			self.clientId,
-			self.clientAddressHash,
+			clientAddressHash,
 			statsStartTime,
 			stats,
 		)

--- a/connect/transport_announce.go
+++ b/connect/transport_announce.go
@@ -160,7 +160,7 @@ func (self *ConnectionAnnounce) run() {
 			self.sendByteCount = 0
 		}()
 
-		stats := &model.ConnectionReliabilityStats{
+		stats := &model.ClientReliabilityStats{
 			ReceiveMessageCount: receiveMessageCount,
 			ReceiveByteCount:    receiveByteCount,
 			SendMessageCount:    sendMessageCount,
@@ -190,7 +190,7 @@ func (self *ConnectionAnnounce) run() {
 			established = true
 			stats.ConnectionNewCount = 1
 		}
-		model.AddConnectionReliabilityStats(
+		model.AddClientReliabilityStats(
 			self.ctx,
 			self.networkId,
 			self.clientId,

--- a/connect/transport_announce.go
+++ b/connect/transport_announce.go
@@ -114,14 +114,14 @@ func (self *ConnectionAnnounce) run() {
 		self.settings.LocationRetryTimeout,
 	)
 	if err != nil {
-		glog.Infof("[t][%s]could not connect client. err = %s\n", hex.EncodeToString(clientAddressHash), err)
+		glog.Infof("[t][%s]could not connect client. err = %s\n", hex.EncodeToString(clientAddressHash[:]), err)
 		return
 	}
 	defer server.HandleError(func() {
 		// note use an uncanceled context for cleanup
 		cleanupCtx := context.Background()
 		model.DisconnectNetworkClient(cleanupCtx, connectionId)
-		glog.V(1).Infof("[t][%s]disconnect client\n", hex.EncodeToString(clientAddressHash))
+		glog.V(1).Infof("[t][%s]disconnect client\n", hex.EncodeToString(clientAddressHash[:]))
 	}, self.cancel)
 
 	self.setConnectionId(connectionId)

--- a/connect/transport_rate_limit.go
+++ b/connect/transport_rate_limit.go
@@ -66,7 +66,7 @@ func NewConnectionRateLimit(
 	if err != nil {
 		return nil, err
 	}
-	clientIpHashHex := hex.EncodeToString(clientIpHash)
+	clientIpHashHex := hex.EncodeToString(clientIpHash[:])
 
 	return &ConnectionRateLimit{
 		ctx:             ctx,

--- a/controller/network_client_controller.go
+++ b/controller/network_client_controller.go
@@ -17,7 +17,7 @@ func ConnectNetworkClient(
 	clientAddress string,
 	handlerId server.Id,
 	retryLocationTimeout time.Duration,
-) (connectionId server.Id, clientAddressHash []byte, err error) {
+) (connectionId server.Id, clientAddressHash [32]byte, err error) {
 	var clientIp string
 	connectionId, clientIp, _, clientAddressHash, err = model.ConnectNetworkClient(ctx, clientId, clientAddress, handlerId)
 	if err != nil {

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -2085,8 +2085,8 @@ var migrations = []any{
 	newSqlMigration(`
         CREATE TABLE client_connection_reliability_score (
             client_id uuid NOT NULL,
-            reliability_score real NOT NULL,
-            reliability_weight real NOT NULL
+            reliability_score double precision NOT NULL,
+            reliability_weight double precision NOT NULL
         )
     `),
 
@@ -2094,8 +2094,8 @@ var migrations = []any{
 	newSqlMigration(`
         CREATE TABLE network_connection_reliability_score (
             network_id uuid NOT NULL,
-            reliability_score real NOT NULL,
-            reliability_weight real NOT NULL
+            reliability_score double precision NOT NULL,
+            reliability_weight double precision NOT NULL
         )
     `),
 

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -2078,9 +2078,13 @@ var migrations = []any{
         CREATE INDEX client_reliability_valid_block_number_client_address_hash ON client_reliability (valid, block_number, client_address_hash)
     `),
 
+	// independent_reliability_score: the total reliability score independent of normalization by ip hash or block window [0, inf)
+	// reliability_score: the total reliability score normalized by ip hash [0, inf)
+	// reliability_weight: the total reliability score normalized by ip hash and block window [0, 1]
 	newSqlMigration(`
         CREATE TABLE client_connection_reliability_score (
             client_id uuid NOT NULL,
+            independent_reliability_score double precision NOT NULL,
             reliability_score double precision NOT NULL,
             reliability_weight double precision NOT NULL,
 
@@ -2088,9 +2092,14 @@ var migrations = []any{
         )
     `),
 
+	// see notes above for:
+	// - independent_reliability_score
+	// - reliability_score
+	// - reliability_weight
 	newSqlMigration(`
         CREATE TABLE network_connection_reliability_score (
             network_id uuid NOT NULL,
+            independent_reliability_score double precision NOT NULL,
             reliability_score double precision NOT NULL,
             reliability_weight double precision NOT NULL,
 

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -2075,27 +2075,26 @@ var migrations = []any{
     `),
 
 	newSqlMigration(`
-        CREATE INDEX client_reliability_client_id_block_number_valid ON client_reliability (client_id, block_number, valid, client_address_hash)
-    `),
-
-	newSqlMigration(`
-        CREATE INDEX client_reliability_network_id_block_number_valid ON client_reliability (network_id, block_number, valid, client_address_hash)
+        CREATE INDEX client_reliability_valid_block_number_client_address_hash ON client_reliability (valid, block_number, client_address_hash)
     `),
 
 	newSqlMigration(`
         CREATE TABLE client_connection_reliability_score (
             client_id uuid NOT NULL,
             reliability_score double precision NOT NULL,
-            reliability_weight double precision NOT NULL
+            reliability_weight double precision NOT NULL,
+
+            PRIMARY KEY (client_id)
         )
     `),
 
-	// FIXME verify real is 64 bit float
 	newSqlMigration(`
         CREATE TABLE network_connection_reliability_score (
             network_id uuid NOT NULL,
             reliability_score double precision NOT NULL,
-            reliability_weight double precision NOT NULL
+            reliability_weight double precision NOT NULL,
+
+            PRIMARY KEY (network_id)
         )
     `),
 

--- a/ip.go
+++ b/ip.go
@@ -40,16 +40,19 @@ var clientIpHashPepper = sync.OnceValue(func() []byte {
 })
 
 func ClientIpHash(clientIp string) ([]byte, error) {
-	parsedAddr, err := netip.ParseAddr(clientIp)
+	addr, err := netip.ParseAddr(clientIp)
 	if err != nil {
 		return nil, err
 	}
+	return ClientIpHashForAddr(addr), nil
+}
 
+func ClientIpHashForAddr(addr netip.Addr) []byte {
 	h := sha256.New()
-	h.Write(parsedAddr.AsSlice())
+	h.Write(addr.AsSlice())
 	h.Write(clientIpHashPepper())
 	clientIpHash := h.Sum(nil)
-	return clientIpHash, nil
+	return clientIpHash
 }
 
 func SplitClientAddress(clientAddress string) (host string, port int, err error) {

--- a/ip.go
+++ b/ip.go
@@ -39,20 +39,27 @@ var clientIpHashPepper = sync.OnceValue(func() []byte {
 	return []byte(pepper)
 })
 
-func ClientIpHash(clientIp string) ([]byte, error) {
+func ClientIpHash(clientIp string) ([32]byte, error) {
 	addr, err := netip.ParseAddr(clientIp)
 	if err != nil {
-		return nil, err
+		return [32]byte{}, err
 	}
 	return ClientIpHashForAddr(addr), nil
 }
 
-func ClientIpHashForAddr(addr netip.Addr) []byte {
+func ClientIpHashForAddr(addr netip.Addr) [32]byte {
+	if addr.Is4() {
+		// for ipv4, use the /27 network
+		addr = netip.PrefixFrom(addr, 27).Masked().Addr()
+	} else if addr.Is6() {
+		// for ipv6, use the /48 network
+		addr = netip.PrefixFrom(addr, 48).Masked().Addr()
+	}
 	h := sha256.New()
 	h.Write(addr.AsSlice())
 	h.Write(clientIpHashPepper())
 	clientIpHash := h.Sum(nil)
-	return clientIpHash
+	return [32]byte(clientIpHash)
 }
 
 func SplitClientAddress(clientAddress string) (host string, port int, err error) {

--- a/model/auth_model_attempt.go
+++ b/model/auth_model_attempt.go
@@ -44,7 +44,7 @@ func UserAuthAttempt(
 			`,
 			userAuthAttemptId,
 			userAuth,
-			clientAddressHash,
+			clientAddressHash[:],
 			clientPort,
 			false,
 		))
@@ -121,7 +121,7 @@ func UserAuthAttempt(
 				ORDER BY attempt_time DESC
 				LIMIT $3
 			`,
-			clientAddressHash,
+			clientAddressHash[:],
 			AttemptLookback/time.Second,
 			AttemptFailedCountThreshold,
 		)

--- a/model/network_client_model.go
+++ b/model/network_client_model.go
@@ -697,6 +697,8 @@ func SetProvide(
 	secretKeys map[ProvideMode][]byte,
 ) {
 	server.Tx(ctx, func(tx server.PgTx) {
+		changeTime := server.NowUtc()
+
 		server.RaisePgResult(tx.Exec(
 			ctx,
 			`
@@ -733,7 +735,7 @@ func SetProvide(
 			) VALUES ($1, $2)
 			`,
 			clientId,
-			server.NowUtc(),
+			changeTime,
 		))
 
 	})
@@ -851,7 +853,7 @@ func ConnectNetworkClient(
 	connectionId server.Id,
 	clientIp string,
 	clientPort int,
-	clientIpHash []byte,
+	clientIpHash [32]byte,
 	err error,
 ) {
 	clientIp, clientPort, err = server.SplitClientAddress(clientAddress)

--- a/model/network_client_model.go
+++ b/model/network_client_model.go
@@ -1082,7 +1082,7 @@ func HeartbeatNetworkClientHandler(ctx context.Context, handlerId server.Id) (re
 	return
 }
 
-func CloseExpiredNetworkClientHandlers(ctx context.Context, timeout time.Duration) {
+func CloseExpiredNetworkClientHandlers(ctx context.Context, minTime time.Time) {
 	server.Tx(ctx, func(tx server.PgTx) {
 		handlerIds := []server.Id{}
 
@@ -1095,7 +1095,7 @@ func CloseExpiredNetworkClientHandlers(ctx context.Context, timeout time.Duratio
 				WHERE 
 					heartbeat_time < $1
 			`,
-			server.NowUtc().Add(-timeout),
+			minTime.UTC(),
 		)
 		server.WithPgResult(result, err, func() {
 			for result.Next() {

--- a/model/network_client_model.go
+++ b/model/network_client_model.go
@@ -744,7 +744,7 @@ func GetProvideKeyChanges(
 	clientId server.Id,
 	minTime time.Time,
 ) (
-	changeCount int,
+	changedCount int,
 	provideModes map[ProvideMode]bool,
 ) {
 	server.Tx(ctx, func(tx server.PgTx) {
@@ -752,7 +752,7 @@ func GetProvideKeyChanges(
 			ctx,
 			`
 			SELECT
-				COUNT(*) AS change_count
+				COUNT(*) AS changed_count
 			FROM provide_key_change
 			WHERE
 				client_id = $1 AND
@@ -763,7 +763,7 @@ func GetProvideKeyChanges(
 		)
 		server.WithPgResult(result, err, func() {
 			if result.Next() {
-				server.Raise(result.Scan(&changeCount))
+				server.Raise(result.Scan(&changedCount))
 			}
 		})
 

--- a/model/network_client_model.go
+++ b/model/network_client_model.go
@@ -896,7 +896,7 @@ func ConnectNetworkClient(
 			host,
 			service,
 			block,
-			clientIpHash,
+			clientIpHash[:],
 			clientPort,
 			handlerId,
 		))

--- a/model/network_client_model_test.go
+++ b/model/network_client_model_test.go
@@ -186,7 +186,7 @@ func TestSetProvide(t *testing.T) {
 			ProvideModePublic: true,
 		})
 
-		RemoveOldProvideKeyChanges(ctx, startTime)
+		RemoveOldProvideKeyChanges(ctx, server.NowUtc())
 
 		changeCount, provideModes = GetProvideKeyChanges(ctx, clientId, startTime)
 		assert.Equal(t, changeCount, 0)

--- a/model/network_client_model_test.go
+++ b/model/network_client_model_test.go
@@ -36,7 +36,7 @@ func TestNetworkClientHandlerLifecycle(t *testing.T) {
 		connected := GetNetworkClientConnectionStatus(ctx, connectionId).Connected
 		assert.Equal(t, connected, true)
 
-		CloseExpiredNetworkClientHandlers(ctx, time.Duration(0))
+		CloseExpiredNetworkClientHandlers(ctx, server.NowUtc())
 
 		connected = GetNetworkClientConnectionStatus(ctx, connectionId).Connected
 		assert.Equal(t, connected, false)
@@ -78,7 +78,7 @@ func TestNetworkClientHandlerLifecycleIPV6(t *testing.T) {
 		connected := GetNetworkClientConnectionStatus(ctx, connectionId).Connected
 		assert.Equal(t, connected, true)
 
-		CloseExpiredNetworkClientHandlers(ctx, time.Duration(0))
+		CloseExpiredNetworkClientHandlers(ctx, server.NowUtc())
 
 		connected = GetNetworkClientConnectionStatus(ctx, connectionId).Connected
 		assert.Equal(t, connected, false)

--- a/model/network_client_reliability_model.go
+++ b/model/network_client_reliability_model.go
@@ -1,0 +1,276 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/urnetwork/server"
+)
+
+const ReliabilityBlockSize = 60 * time.Second
+
+type ConnectionReliabilityStats struct {
+	ReceiveMessageCount        uint64
+	ReceiveByteCount           ByteCount
+	SendMessageCount           uint64
+	SendByteCount              ByteCount
+	ProvideEnabledCount        uint64
+	ProvideChangeCount         uint64
+	ConnectionEstablishedCount uint64
+	ConnectionNewCount         uint64
+}
+
+func AddConnectionReliabilityStats(
+	ctx context.Context,
+	networkId server.Id,
+	clientId server.Id,
+	clientAddressHash []byte,
+	statsTime time.Time,
+	stats *ConnectionReliabilityStats,
+) {
+	blockNumber := statsTime.UTC().UnixMilli() / int64(ReliabilityBlockSize/time.Millisecond)
+
+	server.Tx(ctx, func(tx server.PgTx) {
+		server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+			INSERT INTO client_reliability (
+				block_number,
+				client_address_hash,
+				network_id,
+				client_id,
+				connection_new_count,
+		        connection_established_count,
+		        provide_enabled_count,
+		        provide_changed_count,
+		        receive_message_count,
+		        receive_byte_count,
+		        send_message_count,
+		        send_byte_count
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			ON CONFLICT (block_number, client_address_hash, network_id, client_id) DO UPDATE
+			SET
+				connection_new_count = connection_new_count + $5,
+		        connection_established_count = connection_established_count + $6,
+		        provide_enabled_count = provide_enabled_count + $7,
+		        provide_changed_count = provide_changed_count + $8,
+		        receive_message_count = receive_message_count + $9,
+		        receive_byte_count = receive_byte_count + $10,
+		        send_message_count = send_message_count + $11,
+		        send_byte_count = send_byte_count + $12
+			`,
+			blockNumber,
+			clientAddressHash,
+			networkId,
+			clientId,
+			stats.ConnectionNewCount,
+			stats.ConnectionEstablishedCount,
+			stats.ProvideEnabledCount,
+			stats.ProvideChangeCount,
+			stats.ReceiveMessageCount,
+			stats.ReceiveByteCount,
+			stats.SendMessageCount,
+			stats.SendByteCount,
+		))
+
+	})
+}
+
+func RemoveOldConnectionReliabilityStats(ctx context.Context, minTime time.Time) {
+	minBlockNumber := (minTime.UTC().UnixMilli() / int64(ReliabilityBlockSize/time.Millisecond)) - 1
+
+	server.Tx(ctx, func(tx server.PgTx) {
+		server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+			DELETE FROM client_reliability
+			WHERE block_number <= $1
+			`,
+			minBlockNumber,
+		))
+	})
+}
+
+type ReliabilityScore struct {
+	ReliabilityScore  float64
+	ReliabilityWeight float64
+}
+
+// this should run regulalry to keep the client scores up to date
+func UpdateClientReliabilityScores(ctx context.Context, minTime time.Time, maxTime time.Time) {
+	now := server.NowUtc()
+	minBlockNumber := minTime.UTC().UnixMilli() / int64(ReliabilityBlockSize/time.Millisecond)
+	maxBlockNumber := maxTime.UTC().UnixMilli() / int64(ReliabilityBlockSize/time.Millisecond)
+
+	server.Tx(ctx, func(tx server.PgTx) {
+		server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+			MERGE INTO client_connection_reliability_score
+			USING (
+				SELECT
+					network_id,
+				    client_id,
+				    SUM(1/w.valid_client_count) AS weighted_valid_count
+				FROM client_connection_reliability_blocks
+
+				INNER JOIN (
+					SELECT
+						block_number,
+						client_address_hash,
+						COUNT(*) AS valid_client_count
+					WHERE
+						valid = true
+					GROUP BY block_number, client_address_hash
+				) w ON
+					w.block_number = client_connection_reliability_blocks.block_number AND 
+					w.client_address_hash = client_connection_reliability_blocks.client_address_hash
+
+				WHERE
+					$1 <= block_number AND
+					block_number < $2 AND
+					valid = true
+
+				GROUP BY network_id, client_id
+			) t
+			ON
+				t.client_id = client_connection_reliability_score.client_id AND
+				w.block_number
+				w.client_address_hash = client_connection_reliability_score.client_address_hash
+			WHEN MATCHED THEN UPDATE SET
+			    reliability_score = t.weighted_valid_count,
+			    reliability_weight = t.weighted_valid_count / ($2 - $1 + 1)
+			WHEN NOT MATCHED THEN INSERT (
+				client_id,
+				reliability_score,
+				reliability_weight
+			) VALUES (
+				t.client_id,
+				t.weighted_valid_count,
+				t.weighted_valid_count / ($2 - $1 + 1),
+			)
+			WHEN NOT MATCHED BY SOURCE THEN DELETE
+			`,
+			minBlockNumber,
+			maxBlockNumber,
+		))
+	})
+}
+
+func GetAllClientReliabilityScores(ctx context.Context) map[server.Id]ReliabilityScore {
+	clientScores := map[server.Id]ReliabilityScore{}
+
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+			SELECT
+				client_id,
+				reliability_score,
+				reliability_weight
+			FROM client_connection_reliability_score
+			`,
+		)
+		server.WithPgResult(result, err, func() {
+			for result.Next() {
+				var clientId server.Id
+				var s ReliabilityScore
+				server.Raise(server.Scan(
+					&clientId,
+					&s.ReliabilityScore,
+					&s.ReliabilityWeight,
+				))
+				clientScores[clientId] = s
+			}
+		})
+	})
+
+	return clientScores
+}
+
+// this should run on payout to compute the latest
+func UpdateNetworkReliabilityScoresInTx(tx server.PgTx, ctx context.Context, minTime time.Time, maxTime time.Time) {
+	now := server.NowUtc()
+	minBlockNumber := minTime.UTC().UnixMilli() / int64(ReliabilityBlockSize/time.Millisecond)
+	maxBlockNumber := maxTime.UTC().UnixMilli() / int64(ReliabilityBlockSize/time.Millisecond)
+
+	server.RaisePgResult(tx.Exec(
+		ctx,
+		`
+		MERGE INTO network_connection_reliability_score
+		USING (
+			SELECT
+				network_id,
+			    SUM(1/w.valid_client_count) AS weighted_valid_count
+			FROM client_connection_reliability_blocks
+
+			INNER JOIN (
+				SELECT
+					block_number,
+					client_address_hash,
+					COUNT(*) AS valid_client_count
+				WHERE
+					valid = true
+				GROUP BY block_number, client_address_hash
+			) w ON
+				w.block_number = client_connection_reliability_blocks.block_number AND 
+				w.client_address_hash = client_connection_reliability_blocks.client_address_hash
+
+			WHERE
+				$1 <= block_number AND
+				block_number < $2 AND
+				valid = true
+
+			GROUP BY network_id
+		) t
+		ON
+			t.network_id = network_connection_reliability_score.network_id
+		WHEN MATCHED THEN UPDATE SET
+		    reliability_score = t.weighted_valid_count,
+		    reliability_weight = t.weighted_valid_count / ($2 - $1 + 1)
+		WHEN NOT MATCHED THEN INSERT (
+			network_id,
+			reliability_score,
+			reliability_weight
+		) VALUES (
+			t.network_id,
+			t.weighted_valid_count,
+			t.weighted_valid_count / ($2 - $1 + 1),
+		)
+		WHEN NOT MATCHED BY SOURCE THEN DELETE
+		`,
+		minBlockNumber,
+		maxBlockNumber,
+	))
+}
+
+func GetAllNetworkReliabilityScores(ctx context.Context) map[server.Id]ReliabilityScore {
+	networkScores := map[server.Id]ReliabilityScore{}
+
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+			SELECT
+				network_id,
+				reliability_score,
+				reliability_weight
+			FROM network_connection_reliability_score
+			`,
+		)
+		server.WithPgResult(result, err, func() {
+			for result.Next() {
+				var networkId server.Id
+				var s ReliabilityScore
+				server.Raise(server.Scan(
+					&networkId,
+					&s.ReliabilityScore,
+					&s.ReliabilityWeight,
+				))
+				networkScores[networkId] = s
+			}
+		})
+	})
+
+	return networkScores
+}

--- a/model/network_client_reliability_model_test.go
+++ b/model/network_client_reliability_model_test.go
@@ -64,7 +64,7 @@ func TestAddConnectionReliabilityStats(t *testing.T) {
 		for i := range n {
 			statsTime := startTime.Add(time.Duration(i) * ReliabilityBlockDuration)
 
-			validIpCounts := map[netip.Addr]int{}
+			validIpCounts := map[[32]byte]int{}
 			validBlocks := map[server.Id]int{}
 
 			for networkId, clientIds := range networkClientIds {
@@ -93,7 +93,7 @@ func TestAddConnectionReliabilityStats(t *testing.T) {
 						stats.SendMessageCount = uint64(1 + mathrand.Intn(4))
 						stats.SendByteCount = ByteCount(1024 + mathrand.Intn(8192))
 
-						validIpCounts[ip] += 1
+						validIpCounts[clientAddressHash] += 1
 						validBlocks[clientId] += 1
 					}
 
@@ -110,7 +110,8 @@ func TestAddConnectionReliabilityStats(t *testing.T) {
 
 			for clientId, count := range validBlocks {
 				ip := clientIps[clientId]
-				ipCount := validIpCounts[ip]
+				clientAddressHash := server.ClientIpHashForAddr(ip)
+				ipCount := validIpCounts[clientAddressHash]
 
 				netValidBlocks[clientId] += float64(count) / float64(ipCount)
 			}

--- a/model/network_client_reliability_model_test.go
+++ b/model/network_client_reliability_model_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urnetwork/server"
 )
 
-func TestAddConnectionReliabilityStats(t *testing.T) {
+func TestAddClientReliabilityStats(t *testing.T) {
 	server.DefaultTestEnv().Run(func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -72,7 +72,7 @@ func TestAddConnectionReliabilityStats(t *testing.T) {
 					ip := clientIps[clientId]
 					clientAddressHash := server.ClientIpHashForAddr(ip)
 
-					stats := &ConnectionReliabilityStats{}
+					stats := &ClientReliabilityStats{}
 
 					switch mathrand.Intn(3) {
 					case 0:
@@ -97,7 +97,7 @@ func TestAddConnectionReliabilityStats(t *testing.T) {
 						validBlocks[clientId] += 1
 					}
 
-					AddConnectionReliabilityStats(
+					AddClientReliabilityStats(
 						ctx,
 						networkId,
 						clientId,
@@ -142,7 +142,7 @@ func TestAddConnectionReliabilityStats(t *testing.T) {
 			}
 		}
 
-		RemoveOldConnectionReliabilityStats(ctx, endTime)
+		RemoveOldClientReliabilityStats(ctx, endTime)
 
 	})
 }

--- a/model/network_client_reliability_model_test.go
+++ b/model/network_client_reliability_model_test.go
@@ -1,0 +1,119 @@
+package model
+
+package (
+	"testing"
+)
+
+
+
+func TestAddConnectionReliabilityStats(t *testing.T) {
+
+	ipCount := 30
+	networkCount := 30
+	minClientPerNetworkCount := 1
+	maxClientPerNetworkCount := 8
+	
+
+	ips := []netip.Addr{}
+	// FIXME create ip pool
+
+	networkClientIds := map[server.Id][]server.Id{}
+	clientIps := map[server.Id]netip.Addr{}
+
+	// FIXME create netork, client ids
+	// FIXME assign ips to client ids
+
+
+
+	netValidBlocks := map[server.Id]float64{}
+
+	// for each block, for each client, add one of stats:
+	// - normal
+	// - new connection
+	// - provider change	
+
+	startTime := server.NowUtc()
+	for i := range n {
+		statsTime := startTime.Add(i * ReliabilityBlockDuration)
+
+		validIpCounts := map[netip.Addr]int{}
+		validBlocks := map[server.Id]int{}
+
+		for networkId, clientIds := range networkClientIds {
+			for _, clientId := range clientIds {
+				ip := clientIps[clientId]
+
+
+				stats := &ConnectionReliabilityStats{}
+
+				switch mathrand.Intn(3) {
+				case 0:
+					// connection new
+					
+					stats.ConnectionNewCount = 1 + mathrand.Intn(4)
+				case 1:
+					// provide change
+
+					stats.ProvideChangeCount = 1 + mathrand.Intn(4)
+				default:
+					// normal
+
+					stats.ConnectionEstablishedCount = 1 + mathrand.Intn(4)
+					stats.ProvideEnabledCount = 1 + mathrand.Intn(4)
+					stats.ReceiveMessageCount = 1 + mathrand.Intn(4)
+					stats.ReceiveByteCount = ByteCount(1024 + mathrand.Intn(8192))
+					stats.SendMessageCount = 1 + mathrand.Intn(4)
+					stats.SendByteCount = ByteCount(1024 + mathrand.Intn(8192))
+
+					validIpCounts[ip] += 1
+					validBlocks[clientId] += 1
+				}
+
+				AddConnectionReliabilityStats(
+					ctx,
+					networkId,
+					clientId,
+					clientAddressHash,
+					statsTime,
+					stats,
+				)
+			}
+		}
+
+		for clientId, count := range validBlocks {
+			ip := clientIps[clientId]
+			ipCount := validIpCounts[clientId]
+
+			netValidBlocks[clientId] += float64(count) / float64(ipCount)
+		}
+	}
+	endTime.Add(n * ReliabilityBlockDuration)
+
+
+	UpdateClientReliabilityScores(ctx, startTime, endTime)
+
+	clientScores := GetAllClientReliabilityScores()
+	for clientId, weightedValidBlocks := range netValidBlocks {
+		d := weightedValidBlocks - clientScores[clientId].WeightedValidBlocks
+		if d < e || e < d {
+			assert.Equal(t, weightedValidBlocks, clientScores[clientId].WeightedValidBlocks)
+		}
+	}
+
+	UpdateNetworkReliabilityScores(ctx, startTime, endTime)
+
+	networkScores := GetAllNetworkReliabilityScores()
+	for networkId, clientIds := range networkClientIds {
+		netWeightedValidBlocks := float64(0)
+		for _, clientId := range clientIds {
+			netWeightedValidBlocks += netValidBlocks[clientId]
+		}
+		d := weightedValidBlocks - networkScores[networkId].WeightedValidBlocks
+		if d < e || e < d {
+			assert.Equal(t, weightedValidBlocks, networkScores[networkId].WeightedValidBlocks)
+		}
+	}
+
+	RemoveOldClientReliabilityStats(ctx, endTime)
+
+}

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -107,7 +107,7 @@ func (self *ClientSession) ParseClientIpPort() (ip netip.Addr, port int, err err
 	return
 }
 
-func (self *ClientSession) ClientAddressHashPort() (clientAddressHash []byte, clientPort int, err error) {
+func (self *ClientSession) ClientAddressHashPort() (clientAddressHash [32]byte, clientPort int, err error) {
 	var clientIp string
 	clientIp, clientPort, err = server.SplitClientAddress(self.ClientAddress)
 	if err != nil {

--- a/taskworker/work/network_client_reliability_work.go
+++ b/taskworker/work/network_client_reliability_work.go
@@ -1,10 +1,85 @@
+package work
 
+import (
+	"time"
 
+	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/model"
+	"github.com/urnetwork/server/task"
 
+	// "github.com/urnetwork/server/controller"
+	"github.com/urnetwork/server/session"
+)
 
+type RemoveOldClientReliabilityStatsArgs struct {
+}
 
-// FIXME tasks:
-// - RemoveOldProvideKeyChanges
-// - RemoveOldClientReliabilityStats
-// - UpdateClientReliabilityScores
+type RemoveOldClientReliabilityStatsResult struct {
+}
 
+func ScheduleRemoveOldClientReliabilityStats(clientSession *session.ClientSession, tx server.PgTx) {
+	task.ScheduleTaskInTx(
+		tx,
+		RemoveOldClientReliabilityStats,
+		&RemoveOldClientReliabilityStatsArgs{},
+		clientSession,
+		task.RunOnce("remove_old_client_reliability_stats"),
+		task.RunAt(time.Now().Add(15*time.Minute)),
+	)
+}
+
+func RemoveOldClientReliabilityStats(
+	removeOldClientReliabilityStats *RemoveOldClientReliabilityStatsArgs,
+	clientSession *session.ClientSession,
+) (*RemoveOldClientReliabilityStatsResult, error) {
+	minTime := server.NowUtc().Add(-30 * 24 * time.Hour)
+	model.RemoveOldClientReliabilityStats(clientSession.Ctx, minTime)
+	return &RemoveOldClientReliabilityStatsResult{}, nil
+}
+
+func RemoveOldClientReliabilityStatsPost(
+	removeOldClientReliabilityStats *RemoveOldClientReliabilityStatsArgs,
+	removeOldClientReliabilityStatsResult *RemoveOldClientReliabilityStatsResult,
+	clientSession *session.ClientSession,
+	tx server.PgTx,
+) error {
+	ScheduleRemoveOldClientReliabilityStats(clientSession, tx)
+	return nil
+}
+
+type UpdateClientReliabilityScoresArgs struct {
+}
+
+type UpdateClientReliabilityScoresResult struct {
+}
+
+func ScheduleUpdateClientReliabilityScores(clientSession *session.ClientSession, tx server.PgTx) {
+	task.ScheduleTaskInTx(
+		tx,
+		RemoveOldClientReliabilityStats,
+		&RemoveOldClientReliabilityStatsArgs{},
+		clientSession,
+		task.RunOnce("update_client_reliability_scores"),
+		task.RunAt(time.Now().Add(1*time.Minute)),
+	)
+}
+
+func UpdateClientReliabilityScores(
+	updateClientReliabilityScores *UpdateClientReliabilityScoresArgs,
+	clientSession *session.ClientSession,
+) (*UpdateClientReliabilityScoresResult, error) {
+	// the use case for these stats is match making, which values near term data over long term data
+	minTime := server.NowUtc().Add(-15 * time.Minute)
+	model.UpdateClientReliabilityScores(clientSession.Ctx, minTime, server.NowUtc())
+	return &UpdateClientReliabilityScoresResult{}, nil
+}
+
+func UpdateClientReliabilityScoresPost(
+	updateClientReliabilityScores *UpdateClientReliabilityScoresArgs,
+	updateClientReliabilityScoresResult *UpdateClientReliabilityScoresResult,
+	clientSession *session.ClientSession,
+	tx server.PgTx,
+) error {
+	ScheduleUpdateClientReliabilityScores(clientSession, tx)
+	return nil
+}

--- a/taskworker/work/network_client_reliability_work.go
+++ b/taskworker/work/network_client_reliability_work.go
@@ -1,0 +1,10 @@
+
+
+
+
+
+// FIXME tasks:
+// - RemoveOldProvideKeyChanges
+// - RemoveOldClientReliabilityStats
+// - UpdateClientReliabilityScores
+


### PR DESCRIPTION
Collect data for client reliability and expose it in a usable way for match making and payouts.

Remaining items:
- [x] `GetAll*ReliabilityScoresInTx` to run in an existing tx
- [x] Add tasks for RemoveOldProvideKeyChanges, RemoveOldClientReliabilityStats, UpdateClientReliabilityScores


