### PR TITLE
stripe webhook - searches network by email then fallback to client_reference_id

### DIFF
--- a/model/network_user_model_test.go
+++ b/model/network_user_model_test.go
@@ -192,3 +192,20 @@ func TestAddUserAuthWallet(t *testing.T) {
 
 	})
 }
+
+func TestFindNetworkIdByEmail(t *testing.T) {
+	server.DefaultTestEnv().Run(func() {
+		ctx := context.Background()
+
+		networkId := server.NewId()
+		userId := server.NewId()
+		networkName := "abcdef"
+
+		userAuth := Testing_CreateNetwork(ctx, networkId, networkName, userId)
+
+		retrievedNetworkId, err := FindNetworkIdByEmail(ctx, userAuth)
+		assert.Equal(t, err, nil)
+		assert.Equal(t, *retrievedNetworkId, networkId)
+
+	})
+}


### PR DESCRIPTION
For Stripe subscription webhook
- first search for the network id by email
- if that does not exist, fallback to using client_reference_id for network