### PR TITLE
create referral code in create network tx

### DIFF
--- a/controller/network_controller.go
+++ b/controller/network_controller.go
@@ -22,7 +22,7 @@ func NetworkCreate(
 		return result, nil
 	}
 
-	model.CreateNetworkReferralCode(session.Ctx, result.Network.NetworkId)
+	// model.CreateNetworkReferralCode(session.Ctx, result.Network.NetworkId)
 
 	AddRefreshTransferBalance(session.Ctx, result.Network.NetworkId)
 

--- a/controller/network_controller_test.go
+++ b/controller/network_controller_test.go
@@ -52,6 +52,10 @@ func TestNetworkCreate(t *testing.T) {
 			NetworkId: result.Network.NetworkId,
 		}
 
+		// ensure referral code has been created for this network
+		networkReferralCode := model.GetNetworkReferralCode(session.Ctx, result.Network.NetworkId)
+		assert.NotEqual(t, networkReferralCode, nil)
+
 		// check referral network has points applied
 		// networkPoints = model.FetchNetworkPoints(ctx, referralNetworkId)
 		// assert.Equal(t, len(networkPoints), 1)

--- a/model/network_model.go
+++ b/model/network_model.go
@@ -175,6 +175,8 @@ func NetworkCreate(
 			)
 			server.Raise(err)
 
+			CreateNetworkReferralCodeInTx(session.Ctx, tx, createdNetworkId)
+
 			created = true
 		})
 		if created {
@@ -330,6 +332,8 @@ func NetworkCreate(
 			)
 			server.Raise(err)
 
+			CreateNetworkReferralCodeInTx(session.Ctx, tx, createdNetworkId)
+
 			created = true
 		})
 		if created {
@@ -450,6 +454,8 @@ func NetworkCreate(
 				if err != nil {
 					panic(err)
 				}
+
+				CreateNetworkReferralCodeInTx(session.Ctx, tx, createdNetworkId)
 
 				created = true
 			})
@@ -585,6 +591,8 @@ func NetworkCreate(
 			if err != nil {
 				panic(err)
 			}
+
+			CreateNetworkReferralCodeInTx(session.Ctx, tx, createdNetworkId)
 
 			created = true
 		})

--- a/model/network_referral_code_model.go
+++ b/model/network_referral_code_model.go
@@ -29,31 +29,40 @@ func generateAlphanumericCode(length int) string {
 	return string(code)
 }
 
+func CreateNetworkReferralCodeInTx(ctx context.Context, tx server.PgTx, networkId server.Id) *NetworkReferralCode {
+
+	code := generateAlphanumericCode(6)
+
+	networkReferralCode := &NetworkReferralCode{
+		NetworkId:    networkId,
+		ReferralCode: code,
+	}
+
+	server.RaisePgResult(tx.Exec(
+		ctx,
+		`
+					INSERT INTO network_referral_code (
+							network_id,
+							referral_code
+					)
+					VALUES ($1, $2)
+			`,
+		networkReferralCode.NetworkId,
+		networkReferralCode.ReferralCode,
+	))
+
+	return networkReferralCode
+
+}
+
 func CreateNetworkReferralCode(ctx context.Context, networkId server.Id) *NetworkReferralCode {
 
 	var networkReferralCode *NetworkReferralCode
 
-	code := generateAlphanumericCode(6)
-
 	server.Tx(ctx, func(tx server.PgTx) {
 
-		networkReferralCode = &NetworkReferralCode{
-			NetworkId:    networkId,
-			ReferralCode: code,
-		}
+		networkReferralCode = CreateNetworkReferralCodeInTx(ctx, tx, networkId)
 
-		server.RaisePgResult(tx.Exec(
-			ctx,
-			`
-						INSERT INTO network_referral_code (
-								network_id,
-								referral_code
-						)
-						VALUES ($1, $2)
-				`,
-			networkReferralCode.NetworkId,
-			networkReferralCode.ReferralCode,
-		))
 	})
 
 	return networkReferralCode


### PR DESCRIPTION
Rather than creating the network referral code in a separate tx, populate it in the same tx when creating a new network.
closes #https://github.com/urnetwork/server/issues/320