### PR TITLE
Subscription balance fix

### DIFF
--- a/controller/subscription_controller.go
+++ b/controller/subscription_controller.go
@@ -209,10 +209,10 @@ func SubscriptionBalance(session *session.ClientSession) (*SubscriptionBalanceRe
 		currentSubscription = &Subscription{
 			Plan: model.SubscriptionTypeSupporter,
 		}
-	}
 
-	if market != nil && currentSubscription != nil {
-		currentSubscription.Store = *market
+		if market != nil {
+			currentSubscription.Store = *market
+		}
 	}
 
 	// FIXME


### PR DESCRIPTION
Bugfix when trying to assign the currentSubscription.Store value when currentSubscription was nil, causing a crash.