### PR TITLE
updates adding transfer balance on payment webhooks

### DIFF
--- a/connect/transport_pp_test.go
+++ b/connect/transport_pp_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net"
+
 	// "net/netip"
 	"fmt"
 	"os"

--- a/controller/subscription_controller.go
+++ b/controller/subscription_controller.go
@@ -664,7 +664,7 @@ func stripeHandleInvoicePaid(
 			StartTime:             startTime,
 			EndTime:               endTime,
 			StartBalanceByteCount: RefreshSupporterTransferBalance,
-			NetRevenue:            netRevenue,
+			SubsidyNetRevenue:     netRevenue,
 			BalanceByteCount:      RefreshSupporterTransferBalance,
 		}
 
@@ -1476,7 +1476,7 @@ func PlaySubscriptionRenewal(
 						StartTime:             startTime,
 						EndTime:               endTime,
 						StartBalanceByteCount: RefreshSupporterTransferBalance,
-						NetRevenue:            netRevenue,
+						SubsidyNetRevenue:     netRevenue,
 						BalanceByteCount:      RefreshSupporterTransferBalance,
 						PurchaseToken:         playSubscriptionRenewal.PurchaseToken,
 					}
@@ -1491,7 +1491,7 @@ func PlaySubscriptionRenewal(
 						StartTime:             startTime,
 						EndTime:               maxExpiryTime.Add(SubscriptionGracePeriod),
 						StartBalanceByteCount: sku.BalanceByteCount(),
-						NetRevenue:            model.UsdToNanoCents((1.0 - sku.FeeFraction) * sku.PriceAmountUsd),
+						SubsidyNetRevenue:     model.UsdToNanoCents((1.0 - sku.FeeFraction) * sku.PriceAmountUsd),
 						BalanceByteCount:      sku.BalanceByteCount(),
 						PurchaseToken:         playSubscriptionRenewal.PurchaseToken,
 					}
@@ -1896,7 +1896,7 @@ func HandleSubscribedApple(ctx context.Context, notification AppleNotificationDe
 			StartTime:             startTime,
 			EndTime:               endTime,
 			StartBalanceByteCount: RefreshSupporterTransferBalance,
-			NetRevenue:            netRevenue,
+			SubsidyNetRevenue:     netRevenue,
 			BalanceByteCount:      RefreshSupporterTransferBalance,
 		}
 		model.AddTransferBalance(
@@ -2265,7 +2265,7 @@ func HeliusWebhook(
 			StartTime:             startTime,
 			EndTime:               endTime,
 			StartBalanceByteCount: RefreshSupporterTransferBalance,
-			NetRevenue:            netRevenue,
+			SubsidyNetRevenue:     netRevenue,
 			BalanceByteCount:      RefreshSupporterTransferBalance,
 		}
 		model.AddTransferBalance(

--- a/model/network_client_proxy_model_test.go
+++ b/model/network_client_proxy_model_test.go
@@ -1,11 +1,11 @@
 package model
 
 import (
+	mathrand "math/rand"
 	"testing"
 
 	"github.com/go-playground/assert/v2"
 
-	"github.com/urnetwork/sdk"
 	"github.com/urnetwork/server"
 )
 

--- a/model/subscription_model.go
+++ b/model/subscription_model.go
@@ -589,10 +589,11 @@ type TransferBalance struct {
 	EndTime               time.Time `json:"end_time"`
 	StartBalanceByteCount ByteCount `json:"start_balance_byte_count"`
 	// how much money the platform made after subtracting fees
-	NetRevenue       NanoCents `json:"net_revenue_nano_cents"`
-	BalanceByteCount ByteCount `json:"balance_byte_count"`
-	PurchaseToken    string    `json:"purchase_token,omitempty"`
-	Paid             bool      `json:"paid,omitempty"`
+	NetRevenue        NanoCents `json:"net_revenue_nano_cents"`
+	SubsidyNetRevenue NanoCents `json:"subsidy_net_revenue_nano_cents,omitempty"`
+	BalanceByteCount  ByteCount `json:"balance_byte_count"`
+	PurchaseToken     string    `json:"purchase_token,omitempty"`
+	Paid              bool      `json:"paid,omitempty"`
 }
 
 func GetActiveTransferBalances(ctx context.Context, networkId server.Id) []*TransferBalance {
@@ -680,9 +681,10 @@ func AddTransferBalanceInTx(ctx context.Context, tx server.PgTx, transferBalance
                     start_balance_byte_count,
                     balance_byte_count,
                     net_revenue_nano_cents,
-                    purchase_token
+                    purchase_token,
+                    subsidy_net_revenue_nano_cents
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             `,
 		balanceId,
 		transferBalance.NetworkId,
@@ -692,6 +694,7 @@ func AddTransferBalanceInTx(ctx context.Context, tx server.PgTx, transferBalance
 		transferBalance.BalanceByteCount,
 		transferBalance.NetRevenue,
 		transferBalance.PurchaseToken,
+		transferBalance.SubsidyNetRevenue,
 	))
 
 	transferBalance.BalanceId = balanceId

--- a/model/subscription_model_test.go
+++ b/model/subscription_model_test.go
@@ -1381,7 +1381,7 @@ func TestAccountIsPro(t *testing.T) {
 			StartTime:             startTime,
 			EndTime:               endTime,
 			StartBalanceByteCount: balanceByteCount,
-			NetRevenue:            UsdToNanoCents(40),
+			SubsidyNetRevenue:     UsdToNanoCents(40),
 			BalanceByteCount:      balanceByteCount,
 			PurchaseToken:         "paid_test_token",
 		}


### PR DESCRIPTION
Bug: when we receive a payment webhook, we add transfer_balance, but do not include the net revenue. 

Why are we seeing it now?

We recently updated how we check for pro accounts to search for `transfer_balance.paid == true` and `transfer_balance.active == true`.
This resulted in users paying, but when we check if a user is pro, the API returns false. 
After a day though, when all transfer_balances are refreshed, it is properly swept up and included.

Fix: This PR updates cases of AddRefreshTransferBalance (net_revenue is 0) -> AddTransferBalance (we include net_revenue) in payment webhooks. 