### PR TITLE
fixes reset password query param

### DIFF
--- a/controller/email_templates/auth_password_reset.txt
+++ b/controller/email_templates/auth_password_reset.txt
@@ -1,5 +1,5 @@
 
-Reset your password at https://ur.io/?reset={{.ResetCode}}
+Reset your password at https://ur.io/?resetCode={{.ResetCode}}
 
 If you did not make this change or you believe and unauthorized person has accessed your account, please contact <security@ur.io>.
 


### PR DESCRIPTION
Gets the .txt version inline with the https://github.com/urnetwork/server/blob/main/controller/email_templates/auth_password_reset.html

auth_password_reset.txt version was sending with an incorrect query param, and not prompting the dialog on web.

closes #377 