### PR TITLE
sum paid bytes provided only from account payments that have been completed

### DIFF
--- a/model/account_payment_model.go
+++ b/model/account_payment_model.go
@@ -693,7 +693,7 @@ func GetTransferStats(
 
 				WHERE
 					account_payment.network_id = $1 AND
-					account_payment.canceled
+					account_payment.completed = false
 
 				UNION ALL
 

--- a/model/account_payment_model_test.go
+++ b/model/account_payment_model_test.go
@@ -35,7 +35,7 @@ func TestCancelAccountPayment(t *testing.T) {
 			NetworkId: destinationNetworkId,
 			ClientId:  &destinationId,
 		})
-	
+
 		subscriptionYearDuration := 365 * 24 * time.Hour
 
 		balanceCode, err := CreateBalanceCode(
@@ -216,10 +216,11 @@ func TestGetNetworkProvideStats(t *testing.T) {
 		plan, err := PlanPayments(ctx)
 		assert.Equal(t, err, nil)
 
-		// Since the plan is in progress, should be marked as paid
+		// Since the plan is in progress
+		// and the payments are not marked as completed, should be still marked as unpaid
 		transferStats = GetTransferStats(ctx, destinationNetworkId)
-		assert.Equal(t, transferStats.UnpaidBytesProvided, ByteCount(0))
-		assert.Equal(t, transferStats.PaidBytesProvided, paidByteCount)
+		assert.Equal(t, transferStats.UnpaidBytesProvided, paidByteCount)
+		assert.Equal(t, transferStats.PaidBytesProvided, ByteCount(0))
 
 		// mark plan items as complete
 		for _, payment := range plan.NetworkPayments {
@@ -233,6 +234,7 @@ func TestGetNetworkProvideStats(t *testing.T) {
 			CompletePayment(ctx, payment.PaymentId, "", mockTxHash)
 		}
 
+		// items are completed, should be marked as paid bytes
 		transferStats = GetTransferStats(ctx, destinationNetworkId)
 		assert.Equal(t, transferStats.PaidBytesProvided, paidByteCount)
 		assert.Equal(t, transferStats.UnpaidBytesProvided, ByteCount(0))


### PR DESCRIPTION
We have a user who has never received a payout, as they haven't yet met the payout threshold, but in transfer stats, it is saying they have paid bytes.
Condition added to only sum paid_bytes_provided from completed account payments.
Closes #376 