### PR TITLE
feat: add bulk delete endpoint for offline network clients

### DIFF
--- a/api/handlers/network_client_handlers.go
+++ b/api/handlers/network_client_handlers.go
@@ -16,6 +16,10 @@ func RemoveNetworkClient(w http.ResponseWriter, r *http.Request) {
 	router.WrapWithInputRequireAuth(model.RemoveNetworkClient, w, r)
 }
 
+func RemoveNetworkClients(w http.ResponseWriter, r *http.Request) {
+	router.WrapWithInputRequireAuth(model.RemoveNetworkClients, w, r)
+}
+
 func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 	router.WrapRequireAuth(controller.NetworkRemove, w, r)
 }

--- a/api/main.go
+++ b/api/main.go
@@ -102,6 +102,7 @@ Options:
 		router.NewRoute("POST", "/auth/upgrade-guest-existing", handlers.UpgradeGuestExisting),
 		router.NewRoute("POST", "/network/auth-client", handlers.AuthNetworkClient),
 		router.NewRoute("POST", "/network/remove-client", handlers.RemoveNetworkClient),
+		router.NewRoute("POST", "/network/remove-clients", handlers.RemoveNetworkClients),
 		router.NewRoute("GET", "/network/clients", handlers.NetworkClients),
 		router.NewRoute("GET", "/network/provider-locations", handlers.NetworkGetProviderLocations),
 		router.NewRoute("POST", "/network/find-provider-locations", handlers.NetworkFindProviderLocations),

--- a/model/network_client_model.go
+++ b/model/network_client_model.go
@@ -445,6 +445,43 @@ func RemoveNetworkClient(
 	return removeClientResult, removeClientErr
 }
 
+type RemoveNetworkClientsArgs struct {
+	ClientIds []server.Id `json:"client_ids"`
+}
+
+type RemoveNetworkClientsResult struct{}
+
+func RemoveNetworkClients(
+	removeClients *RemoveNetworkClientsArgs,
+	session *session.ClientSession,
+) (*RemoveNetworkClientsResult, error) {
+	var removeClientsResult *RemoveNetworkClientsResult
+	if len(removeClients.ClientIds) == 0 {
+		return &RemoveNetworkClientsResult{}, nil
+	}
+
+	server.Tx(session.Ctx, func(tx server.PgTx) {
+		_, err := tx.Exec(
+			session.Ctx,
+			`
+				UPDATE network_client
+				SET
+					active = false
+				WHERE
+					client_id = ANY($1) AND
+					network_id = $2
+			`,
+			removeClients.ClientIds,
+			session.ByJwt.NetworkId,
+		)
+		server.Raise(err)
+
+		removeClientsResult = &RemoveNetworkClientsResult{}
+	})
+
+	return removeClientsResult, nil
+}
+
 type NetworkClientsResult struct {
 	Clients []*NetworkClientInfo `json:"clients"`
 }

--- a/model/network_client_model_test.go
+++ b/model/network_client_model_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-playground/assert/v2"
 
 	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/jwt"
+	"github.com/urnetwork/server/session"
 )
 
 func TestNetworkClientHandlerLifecycle(t *testing.T) {
@@ -194,5 +196,33 @@ func TestSetProvide(t *testing.T) {
 			ProvideModePublic: true,
 		})
 
+	})
+}
+
+func TestRemoveNetworkClients(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+		networkId := server.NewId()
+
+		// Create a mock session
+		sess := &session.ClientSession{
+			Ctx: ctx,
+			ByJwt: &jwt.ByJwt{
+				NetworkId: networkId,
+			},
+		}
+
+		// Generate random IDs to test the ANY($1) binding
+		clientIds := []server.Id{server.NewId(), server.NewId(), server.NewId()}
+
+		args := &RemoveNetworkClientsArgs{
+			ClientIds: clientIds,
+		}
+
+		// This will panic if the driver fails to cast []server.Id to uuid[]
+		_, err := RemoveNetworkClients(args, sess)
+		
+		// Assert that the function ran without returning an error
+		assert.Equal(t, err, nil)
 	})
 }

--- a/model/network_client_model_test.go
+++ b/model/network_client_model_test.go
@@ -221,7 +221,7 @@ func TestRemoveNetworkClients(t *testing.T) {
 
 		// This will panic if the driver fails to cast []server.Id to uuid[]
 		_, err := RemoveNetworkClients(args, sess)
-		
+
 		// Assert that the function ran without returning an error
 		assert.Equal(t, err, nil)
 	})


### PR DESCRIPTION
This PR introduces a bulk deletion endpoint for network clients to resolve the performance bottleneck where the dashboard was forced to issue hundreds of sequential HTTP requests to clean up offline clients.

I added a new `RemoveNetworkClients` model function and a `POST /network/remove-clients` API handler. This processes the deletions efficiently in a single, atomic PostgreSQL `ANY($1)` update operation. 

Network scoping (`network_id = $2`) is strictly enforced to prevent insecure direct object references, and I've included a unit test to verify the UUID array binding logic.