### PR TITLE
fix: AuthNetworkClient panics when ClientId is set (two bugs in reuse path)

### DIFF
--- a/model/network_client_model.go
+++ b/model/network_client_model.go
@@ -347,14 +347,16 @@ func AuthNetworkClient(
 				`,
 				authClient.ClientId,
 			)
-			var deviceId *server.Id
-			server.WithPgResult(result, err, func() {
-				if result.Next() {
-					server.Raise(result.Scan(deviceId))
-				}
-			})
+		var deviceId server.Id
+		var hasDevice bool
+		server.WithPgResult(result, err, func() {
+			if result.Next() {
+				server.Raise(result.Scan(&deviceId))
+				hasDevice = true
+			}
+		})
 
-			if deviceId == nil {
+		if !hasDevice {
 				authClientResult = &AuthNetworkClientResult{
 					Error: &AuthNetworkClientError{
 						Message: "Client needs to be migrated (support@ur.io).",
@@ -368,7 +370,7 @@ func AuthNetworkClient(
 				`
 					UPDATE device
 					SET
-						device_spec = $2,
+						device_spec = $2
 					WHERE
 						device_id = $1
 				`,
@@ -384,7 +386,7 @@ func AuthNetworkClient(
 				return
 			}
 
-			byJwtWithClientId := session.ByJwt.Client(*deviceId, *authClient.ClientId).Sign()
+			byJwtWithClientId := session.ByJwt.Client(deviceId, *authClient.ClientId).Sign()
 			authClientResult = &AuthNetworkClientResult{
 				ByClientJwt: &byJwtWithClientId,
 				ClientId:    authClient.ClientId,

--- a/model/network_client_model_test.go
+++ b/model/network_client_model_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-playground/assert/v2"
 
 	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/jwt"
+	"github.com/urnetwork/server/session"
 )
 
 func TestNetworkClientHandlerLifecycle(t *testing.T) {
@@ -383,5 +385,59 @@ func TestMigrateProvideMode(t *testing.T) {
 			networkSk, _ := r.Get(ctx, provideModeSecretKeyKey(clientId, ProvideModeNetwork)).Result()
 			assert.Equal(t, []byte(networkSk), networkKey)
 		})
+	})
+}
+
+func TestAuthNetworkClientReuse(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		networkId := server.NewId()
+		userId := server.NewId()
+		networkName := "test-reuse"
+
+		Testing_CreateNetwork(ctx, networkId, networkName, userId)
+
+		authSessionId := server.NewId()
+		byJwt := jwt.NewByJwt(networkId, userId, networkName, false, false, authSessionId)
+		signed := byJwt.Sign()
+		parsedByJwt, parseErr := jwt.ParseByJwt(ctx, signed)
+		assert.Equal(t, parseErr, nil)
+
+		cancelCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		sess := &session.ClientSession{
+			Ctx:    cancelCtx,
+			Cancel: cancel,
+			ByJwt:  parsedByJwt,
+		}
+
+		// Mint a fresh client (ClientId == nil)
+		createResult, createErr := AuthNetworkClient(
+			&AuthNetworkClientArgs{
+				Description: "test-client",
+				ClientId:    nil,
+			},
+			sess,
+		)
+		assert.Equal(t, createErr, nil)
+		assert.NotEqual(t, createResult, nil)
+		assert.NotEqual(t, createResult.ByClientJwt, nil)
+		assert.NotEqual(t, createResult.ClientId, nil)
+		createdId := *createResult.ClientId
+
+		// Reuse the client (ClientId != nil) — this was the broken path
+		reuseResult, reuseErr := AuthNetworkClient(
+			&AuthNetworkClientArgs{
+				Description: "test-client-reuse",
+				ClientId:    &createdId,
+			},
+			sess,
+		)
+		assert.Equal(t, reuseErr, nil)
+		assert.NotEqual(t, reuseResult, nil)
+		assert.NotEqual(t, reuseResult.ByClientJwt, nil)
+		assert.NotEqual(t, reuseResult.ClientId, nil)
+		assert.Equal(t, *reuseResult.ClientId, createdId)
 	})
 }


### PR DESCRIPTION
Fix two bugs in AuthNetworkClient's ClientId reuse path

The AuthNetworkClient endpoint supports an optional ClientId field 
to re-authenticate an existing client identity, but the branch that 
handles ClientId != nil has two bugs that cause it to panic every time:

1. nil pointer dereference in Scan (line 353)
   - deviceId is declared as *server.Id (nil pointer)
   - result.Scan(deviceId) scans into nil, which calls (*Id).Scan(src)
     with a nil receiver, causing a panic at `*self = Id(id)`
   - Fixed by using value type + hasDevice bool, matching the pattern
     in the working ClientId == nil branch

2. Trailing comma in SQL UPDATE (line 371)
   - `device_spec = $2,` has an extra comma before WHERE
   - PostgreSQL rejects this as a syntax error
   - Fixed by removing the comma

Neither bug has test coverage because no caller in the codebase 
ever sets ClientId. The bugs were confirmed against the live API 
at api.bringyour.com, which returns HTTP 500 for this path.