### PR TITLE
fix(api): return [] not null for empty leaderboard and account points

### DIFF
--- a/controller/leaderboard_controller.go
+++ b/controller/leaderboard_controller.go
@@ -23,6 +23,12 @@ func GetLeaderboard(
 	earners, err := model.GetLeaderboard(session.Ctx)
 	if err != nil {
 		return &model.LeaderboardResult{
+			// Earners must be non-nil even on the error path: the client
+			// deserialises the whole result before reading Error, and a nil
+			// slice here marshals as `null`, which crashes the android client
+			// exactly as an empty leaderboard did. A transient query error must
+			// not take the app down.
+			Earners: []model.Earner{},
 			Error: &model.TopEarnersError{
 				Message: err.Error(),
 			},

--- a/model/account_point_model.go
+++ b/model/account_point_model.go
@@ -131,6 +131,11 @@ func ApplyAccountPointsBatchInTx(
 }
 
 func FetchAccountPoints(ctx context.Context, networkId server.Id) (accountPoints []AccountPoint) {
+	// non-nil for the same reason as GetLeaderboard: a nil slice becomes JSON
+	// `null`, which the gomobile binding turns into a nil pointer and the
+	// android client crashes on. Feeds both `network_points` and its
+	// `account_points` alias.
+	accountPoints = []AccountPoint{}
 
 	server.Db(ctx, func(conn server.PgConn) {
 		result, err := conn.Query(

--- a/model/leaderboard_model.go
+++ b/model/leaderboard_model.go
@@ -28,6 +28,11 @@ type TopEarnersError struct {
  * Gets an ordered list of the top earners
  */
 func GetLeaderboard(ctx context.Context) (earners []Earner, queryErr error) {
+	// must be non-nil: a nil slice marshals as JSON `null`, and the gomobile
+	// sdk binds this field as a pointer, so `null` becomes a nil object that
+	// the android client dereferences inside a jni callback -- the NPE cannot
+	// cross jni and ART aborts the whole process. An empty leaderboard is `[]`.
+	earners = []Earner{}
 
 	// stats read: tolerates replica delay
 	server.ReplicaDb(ctx, func(conn server.PgConn) {

--- a/model/nil_slice_json_test.go
+++ b/model/nil_slice_json_test.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/urnetwork/server"
+)
+
+// A nil slice marshals as JSON `null`. The gomobile sdk binds these fields as
+// pointers, so `null` becomes a nil object the android client dereferences
+// inside a jni callback; the NPE cannot cross jni and ART aborts the process.
+// An API slice that can legitimately be empty must serialise as `[]`.
+//
+// These assert on the marshalled bytes, because `[]` versus `null` is the
+// property that actually reaches the client.
+
+func TestGetLeaderboardEmptyMarshalsAsArrayNotNull(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		// a fresh db has no payouts, so the query returns zero rows -- the
+		// exact condition that crashed the android client
+		earners, err := GetLeaderboard(ctx)
+		if err != nil {
+			t.Fatalf("GetLeaderboard: %s", err)
+		}
+		if earners == nil {
+			t.Fatal("GetLeaderboard returned a nil slice; it marshals as null and crashes the client")
+		}
+
+		b, err := json.Marshal(LeaderboardResult{Earners: earners})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(b), `"earners":[]`) {
+			t.Errorf("marshalled as %s, want \"earners\":[]", b)
+		}
+	})
+}
+
+func TestFetchAccountPointsEmptyMarshalsAsArrayNotNull(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		// a network with no points at all -- feeds both `network_points` and
+		// its `account_points` alias
+		points := FetchAccountPoints(ctx, server.NewId())
+		if points == nil {
+			t.Fatal("FetchAccountPoints returned a nil slice; it marshals as null and crashes the client")
+		}
+
+		b, err := json.Marshal(map[string]any{"network_points": points})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(b), "null") {
+			t.Errorf("marshalled as %s, want an empty array", b)
+		}
+	})
+}


### PR DESCRIPTION
A nil slice marshals as JSON `null`. The gomobile sdk binds these fields as pointers, so `null` becomes a nil object that the Android client dereferences inside a JNI callback — the NPE cannot cross JNI and ART aborts the whole process:

```
JNI DETECTED ERROR IN APPLICATION: CallStaticVoidMethod called with pending exception
java.lang.NullPointerException: ...LeaderboardEarnersList.len() on a null object reference
```

Confirmed on device: opening the Leaderboard tab hard-crashes the app. This hits any deployment whose leaderboard query returns zero rows — a new or custom server, or one before its first payout cycle.

Reproduced live before the fix, and verified after:

```
before:  /stats/leaderboard -> {"earners":null}
         /account/points    -> {"account_points":null,"network_points":null}
after:   /stats/leaderboard -> {"earners":[]}
         /account/points    -> {"account_points":[],"network_points":[]}
```

## Three instances

1. `model.GetLeaderboard` — `earners` is a named return that is only ever appended to, so zero rows leaves it nil.
2. `controller.GetLeaderboard` **error path** — returns a result with only `Error` set, leaving `Earners` nil, so a transient query error crashes the app exactly as an empty leaderboard does.
3. `model.FetchAccountPoints` — identical shape, feeding both `network_points` and its dual-emitted `account_points` alias, so `/account/points` returned two null fields.

## Not affected

`GetNetworkLeaderboardRanking` returns a `NetworkRanking` **value**, not a pointer, so a network with no payouts already serialises as an object. A nil `*NetworkRanking` on the client is the binding reflecting the JSON and resolves with the above.

## Audit of the whole class

Every function in `model/` and `controller/` with a named slice return that is only appended to: six matches, of which only the two above are API-facing. `listClientReliabilityPartitions` and `MaintainClientReliabilityPartitions` are internal maintenance, `GetProxyIdsSince` has no controller caller, and `GetCircleUCUsers` feeds internal processing.

## Tests

DB-backed, calling the real functions against an empty database and asserting on the **marshalled bytes** rather than on non-nilness — `[]` versus `null` is the property that actually reaches the client. Teeth-checked: removing either initialisation fails them with "returned a nil slice; it marshals as null and crashes the client".

Note: `TestAccountPoints` in the controller package fails, but fails identically on the parent commit (same panic at `account_point_controller_test.go:16`) — pre-existing and unrelated to this change.