### PR TITLE
Shard the provider-egress queue and make its ceiling configurable

### DIFF
--- a/api/handlers/provider_egress_location_handlers.go
+++ b/api/handlers/provider_egress_location_handlers.go
@@ -151,11 +151,52 @@ const (
 	// defaultProviderEgressDueLimit is the batch size when the caller does not
 	// ask for one.
 	defaultProviderEgressDueLimit = 100
-	// maxProviderEgressDueLimit bounds the batch size regardless of what the
-	// caller asks for, so one request cannot ask the database for the entire
-	// provider population.
-	maxProviderEgressDueLimit = 500
+	// defaultMaxProviderEgressDueLimit bounds the batch size regardless of what
+	// the caller asks for, so one request cannot ask the database for the
+	// entire provider population.
+	//
+	// This is the FALLBACK. The effective value comes from
+	// provider_egress_due.yml -- see maxProviderEgressDueLimit below.
+	defaultMaxProviderEgressDueLimit = 500
 )
+
+// maxProviderEgressDueLimit is the ceiling on one due batch, read from
+// provider_egress_due.yml.
+//
+// It is configuration, not a constant, for the same reason the bandwidth budget
+// is (see provider_bandwidth.yml): capacity is a property of the deployment.
+// The 500 fallback is sized for a beta-scale fleet. A deployment holding ~100k
+// providers needs a different regime entirely -- at a 6h re-probe backoff that
+// is ~16,700 probes/hour, and a 500-per-request ceiling caps the whole fleet at
+// 500/hour no matter how much prober capacity exists behind it.
+//
+// OPTIONAL, exactly like provider_bandwidth.yml and pro.yml: a deployment
+// without the file must not fail to boot, it falls back to the conservative
+// default.
+var maxProviderEgressDueLimit = sync.OnceValue(func() int {
+	resource, err := server.Config.SimpleResource("provider_egress_due.yml")
+	if err != nil {
+		glog.Infof(
+			"[pegl]provider_egress_due.yml not present; using the default due limit of %d\n",
+			defaultMaxProviderEgressDueLimit,
+		)
+		return defaultMaxProviderEgressDueLimit
+	}
+	var y struct {
+		MaxDueLimit int `yaml:"max_due_limit"`
+	}
+	resource.UnmarshalYaml(&y)
+	if y.MaxDueLimit <= 0 {
+		glog.Errorf(
+			"[pegl]provider_egress_due.yml has max_due_limit=%d, which is not usable; using the default %d\n",
+			y.MaxDueLimit,
+			defaultMaxProviderEgressDueLimit,
+		)
+		return defaultMaxProviderEgressDueLimit
+	}
+	glog.Infof("[pegl]max due limit: %d from provider_egress_due.yml\n", y.MaxDueLimit)
+	return y.MaxDueLimit
+})
 
 // providerEgressDueAge is how stale a stored probe must be before its provider
 // is offered up for re-probing. It is deliberately shorter than
@@ -208,7 +249,35 @@ func ProviderEgressLocationDue(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
-		limit = min(parsed, maxProviderEgressDueLimit)
+		limit = min(parsed, maxProviderEgressDueLimit())
+	}
+
+	// shard_index / shard_count partition the queue across independent probers.
+	// Absent (or shard_count=1) is the single-prober case and behaves exactly as
+	// before, so an existing prober needs no change.
+	//
+	// Without this, every prober polling inside the attempt backoff gets the
+	// SAME rows -- the queue hands work out but never claims it -- so N probers
+	// repeat one prober's work instead of dividing it.
+	shardCount := 1
+	shardIndex := 0
+	if raw := r.URL.Query().Get("shard_count"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		shardCount = parsed
+	}
+	if raw := r.URL.Query().Get("shard_index"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		// an out-of-range index would silently return nothing forever, which
+		// looks identical to "the fleet is fully probed" -- reject it instead
+		if err != nil || parsed < 0 || shardCount <= parsed {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		shardIndex = parsed
 	}
 
 	// both cutoffs are computed here and passed as arguments; observed_at and
@@ -219,7 +288,14 @@ func ProviderEgressLocationDue(w http.ResponseWriter, r *http.Request) {
 	minAttemptAt := now.Add(-model.ProviderEgressProbeAttemptBackoff)
 
 	result := &ProviderEgressLocationDueResult{
-		ClientIds: model.GetProviderEgressLocationDue(r.Context(), minObservedAt, minAttemptAt, limit),
+		ClientIds: model.GetProviderEgressLocationDueSharded(
+			r.Context(),
+			minObservedAt,
+			minAttemptAt,
+			limit,
+			shardIndex,
+			shardCount,
+		),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/beta-vault/config/provider_egress_due.yml.example
+++ b/beta-vault/config/provider_egress_due.yml.example
@@ -1,0 +1,18 @@
+# Ceiling on one provider-egress due batch, for THIS deployment.
+#
+# Capacity is a property of the deployment, so each one sets its own -- the same
+# reasoning as provider_bandwidth.yml. Absent, the server falls back to 500,
+# which is sized for a beta-scale fleet.
+#
+# Sizing: a prober sustains roughly (concurrency / probe_duration) probes per
+# hour -- measured at ~20/hour per concurrent slot, a probe being ~3 min because
+# a dead provider burns the full probe timeout across all destinations. The
+# batch has to cover one poll interval:
+#
+#   max_due_limit >= concurrency * (interval / probe_duration)
+#
+# For a fleet of ~100k on the 6h attempt backoff that is ~16,700 probes/hour
+# fleet-wide; split across N probers with shard_count=N, each needs its own
+# share of that. 500 caps the whole fleet at 500/hour regardless of how much
+# prober capacity sits behind it.
+max_due_limit: 500

--- a/model/provider_egress_location_model.go
+++ b/model/provider_egress_location_model.go
@@ -903,11 +903,41 @@ func matchChildLocation(
 // quantify over. The same holds for `observed_at IS NULL` on
 // provider_egress_location, whose client_id is likewise a primary key and whose
 // observed_at is NOT NULL: the only way that test is true is that no row exists.
+// GetProviderEgressLocationDue is the unsharded queue: one prober takes the
+// whole fleet. Equivalent to GetProviderEgressLocationDueSharded with a single
+// shard, and kept so existing callers are unaffected.
 func GetProviderEgressLocationDue(
 	ctx context.Context,
 	minObservedAt time.Time,
 	minAttemptAt time.Time,
 	limit int,
+) []server.Id {
+	return GetProviderEgressLocationDueSharded(ctx, minObservedAt, minAttemptAt, limit, 0, 1)
+}
+
+// GetProviderEgressLocationDueSharded partitions the queue across independent
+// probers via shardIndex/shardCount.
+//
+// Without partitioning, every prober polling inside the attempt-backoff window
+// receives the SAME rows. The queue hands work out but never claims it, and the
+// deduplicating NOT EXISTS on provider_egress_probe_attempt only bites once an
+// attempt row lands -- at submit time, minutes after the batch went out, which
+// is exactly when the other probers are polling. N probers therefore repeat the
+// same work, and throughput does not rise as hosts are added.
+//
+// Hashing client_id gives each prober a disjoint slice with no locks, no leases
+// and no new columns, which suits a fixed set of hosts. A prober that goes away
+// leaves its slice unprobed until it returns, rather than stranding a claim
+// that something then has to reap.
+//
+// shardCount <= 1 disables sharding, which is the single-prober case.
+func GetProviderEgressLocationDueSharded(
+	ctx context.Context,
+	minObservedAt time.Time,
+	minAttemptAt time.Time,
+	limit int,
+	shardIndex int,
+	shardCount int,
 ) []server.Id {
 	clientIds := []server.Id{}
 	server.Db(ctx, func(conn server.PgConn) {
@@ -944,6 +974,16 @@ func GetProviderEgressLocationDue(
 					WHERE
 						provider_egress_probe_attempt.client_id = network_client_location_reliability.client_id AND
 						$2 <= provider_egress_probe_attempt.attempt_at
+				) AND
+				-- shard partition. hashtext returns a SIGNED int32 and postgres
+				-- '%' keeps the sign of the dividend, so a bare
+				-- hashtext(...) % n = i never matches the negative half of the
+				-- hash space and roughly half the fleet would never be probed.
+				-- The extra (+ n) % n normalises into [0, n).
+				-- $4 <= 1 short-circuits to the unsharded behaviour.
+				(
+					$4 <= 1 OR
+					((hashtext(network_client_location_reliability.client_id::text) % $4) + $4) % $4 = $5
 				)
 
 			ORDER BY network_client_location_reliability.client_id ASC
@@ -952,6 +992,8 @@ func GetProviderEgressLocationDue(
 			ProvideModePublic,
 			minAttemptAt.UTC(),
 			limit,
+			shardCount,
+			shardIndex,
 		)
 		server.WithPgResult(result, err, func() {
 			for result.Next() {
@@ -998,6 +1040,12 @@ func GetProviderEgressLocationDue(
 					WHERE
 						provider_egress_probe_attempt.client_id = provider_egress_location.client_id AND
 						$3 <= provider_egress_probe_attempt.attempt_at
+				) AND
+				-- the same shard partition as pass 1; see the note there for why
+				-- the modulo has to be normalised. $5 <= 1 is the unsharded case.
+				(
+					$5 <= 1 OR
+					((hashtext(provider_egress_location.client_id::text) % $5) + $5) % $5 = $6
 				)
 
 			-- oldest probe first, client_id breaking the tie, so batch
@@ -1011,6 +1059,8 @@ func GetProviderEgressLocationDue(
 			minObservedAt.UTC(),
 			minAttemptAt.UTC(),
 			remaining,
+			shardCount,
+			shardIndex,
 		)
 		server.WithPgResult(result, err, func() {
 			// the two passes are separate statements and so separate snapshots.


### PR DESCRIPTION
Follow-up to #429, now that the provider-egress subsystem is on `main`. Two changes so a fleet the size of mainnet's can actually be probed. Both are **inert unless a deployment opts in** — every existing deployment behaves exactly as it does today.

### 1. The queue hands work out but never claims it

`GetProviderEgressLocationDue` has no lease, no `FOR UPDATE`, no partition key. The deduplicating `NOT EXISTS` on `provider_egress_probe_attempt` only takes effect once an attempt row lands — at submit time, minutes after the batch went out, which is precisely when the other probers are polling.

So every prober polling inside the attempt-backoff window receives **the same rows**. N probers repeat one prober's work, and throughput does not rise as hosts are added: six edge servers currently buy nothing over one.

`GetProviderEgressLocationDueSharded` adds `shardIndex`/`shardCount`, surfaced as `shard_index` / `shard_count` on `/network/provider-egress-due`. Hashing `client_id` gives each prober a disjoint slice with no locks, no leases and no new columns, which suits a fixed set of hosts — a prober that goes away leaves its slice unprobed until it returns, rather than stranding a claim something has to reap. `FOR UPDATE SKIP LOCKED` or a `claimed_until` column would be more robust to probers appearing and disappearing, at the cost of write load on the busiest path and a reaper; worth doing if probers ever become dynamic.

`GetProviderEgressLocationDue` is kept as a single-shard wrapper, so **none of the 13 existing call sites change**.

**The modulo is normalised, and this is the part to review closely.** `hashtext` returns a *signed* int32 and postgres `%` keeps the sign of the dividend, so the obvious `hashtext(...) % n = i` never matches the negative half of the hash space — roughly half the fleet would silently never be probed, and it would look exactly like an empty queue. Verified against postgres 16 over 20k ids:

```
normalised ((h % 6) + 6) % 6  ->  6 of 6 shards, ~3.3k rows each
naive       h % 6             ->  11 distinct values (-5..5)
```

An out-of-range `shard_index` returns 400 rather than an empty list, since "no rows" is otherwise indistinguishable from "the fleet is fully probed".

### 2. The batch ceiling becomes configuration

`maxProviderEgressDueLimit` moves to an **optional** `provider_egress_due.yml`, following `provider_bandwidth.yml` — whose own comment states the rule: *"Capacity is a property of the deployment, so each one sets its own. Mainnet must measure its own limits."*

The 500 fallback is beta-sized. At ~100k providers on the 6h attempt backoff the fleet needs ~16,700 probes/hour, and a 500-per-request ceiling caps it at 500/hour regardless of how much prober capacity sits behind it. A deployment without the file keeps 500. **No deployment-specific value is committed** — only the example.

### Live tested on a real deployment

Against a live database, not a fixture:

```
unsharded set:      49
union of 6 shards:  49
sum of shard sizes: 49

COMPLETE (union == unsharded):  true
DISJOINT (no id in 2 shards):   true
ids in more than one shard:     0
```

Also confirmed: `shard_count=1` returns results identical to unsharded; shard assignment is stable across repeated calls; `shard_index=6` with `shard_count=6`, negative index, `shard_count=0` and non-numeric input all return 400; no errors in the api log.

### Not included

The probe/speedtest split discussed in #429 is not here. The speedtest currently rides the geolocation probe's tunnel (`prober.go`), so decoupling them is a separate change spanning the prober repo, and the cost of a second tunnel setup should be measured before committing to it.
