### PR TITLE
Remove beta-branch references: dangling planning-doc citations and beta-vault example

### DIFF
--- a/db_migrations.go
+++ b/db_migrations.go
@@ -4881,11 +4881,10 @@ var migrations = []any{
 	// GetProviderEgressLocationDue defers on a recent attempt as well as a fresh
 	// success, which needs somewhere to record the attempt.
 	//
-	// Pulled forward from the P2 verdict model
-	// (docs/superpowers/specs/2026-07-25-enforced-provider-geo-probing-design.md,
-	// probe_attempt_at / probe_failure) because the P1 schedule cannot function
-	// without it. Deliberately only the two columns the schedule reads, not the
-	// rest of that model.
+	// Pulled forward from the larger provider-verdict model (probe_attempt_at
+	// / probe_failure) because the due schedule cannot function without it.
+	// Deliberately only the two columns the schedule reads, not the rest of
+	// that model.
 	newSqlMigration(`
         CREATE TABLE IF NOT EXISTS provider_egress_probe_attempt (
             client_id     uuid NOT NULL PRIMARY KEY,

--- a/docs/operator/provider_egress_due.yml.example
+++ b/docs/operator/provider_egress_due.yml.example
@@ -1,8 +1,13 @@
 # Ceiling on one provider-egress due batch, for THIS deployment.
 #
+# Install as `provider_egress_due.yml` in the deployment's CONFIG home --
+# $WARP_CONFIG_HOME, else $WARP_HOME/config -- alongside provider_bandwidth.yml.
+# It is read through server.Config (a config mount), not the vault, despite
+# holding no secret worth vaulting.
+#
 # Capacity is a property of the deployment, so each one sets its own -- the same
 # reasoning as provider_bandwidth.yml. Absent, the server falls back to 500,
-# which is sized for a beta-scale fleet.
+# which is sized for a fleet of a few dozen providers.
 #
 # Sizing: a prober sustains roughly (concurrency / probe_duration) probes per
 # hour -- measured at ~20/hour per concurrent slot, a probe being ~3 min because

--- a/model/provider_bandwidth_model.go
+++ b/model/provider_bandwidth_model.go
@@ -120,10 +120,9 @@ func ComputePassiveProviderBandwidth(
 				-- companion_contract_id IS NULL excludes return-traffic legs: a
 				-- client's return traffic settles as a contract where the CLIENT
 				-- is the destination, which would otherwise be misread as that
-				-- client acting as a fast provider. See
-				-- docs/superpowers/specs/2026-07-25-enforced-provider-geo-probing-design.md
-				-- "Threat model" -- confirmed empirically: on beta, every
-				-- non-Public-key "earner" turned out to be exactly this.
+				-- client acting as a fast provider. Confirmed empirically on a
+				-- live deployment: every non-Public-key "earner" turned out to
+				-- be exactly this.
 				transfer_contract.companion_contract_id IS NULL AND
 				$2 <= contract_close.close_time
 			`,


### PR DESCRIPTION
Follow-up to #429 and #430. Removes three references to the branch this work was developed on, none of which mean anything in this repository. **Comment and documentation only — no code, no behavior, no schema change.**

### Dangling planning-doc citations

Two comments cite `docs/superpowers/specs/2026-07-25-enforced-provider-geo-probing-design.md`:

- [`db_migrations.go:4884`](https://github.com/urnetwork/server/blob/main/db_migrations.go#L4884) — why `provider_egress_probe_attempt` carries only two columns
- [`model/provider_bandwidth_model.go:123`](https://github.com/urnetwork/server/blob/main/model/provider_bandwidth_model.go#L123) — why `companion_contract_id IS NULL` excludes return-traffic legs

`docs/` in this repo holds `api-spec-gaps.md` and `operator/`, and never held that path. A reader who follows the citation finds nothing and cannot tell whether the rationale was lost or was never written down.

Both keep their reasoning and drop the citation. The bandwidth comment keeps the empirical finding that motivated the clause — *every non-Public-key "earner" turned out to be exactly this* — since that is the part worth having; it just no longer attributes it to an unreachable document.

### `beta-vault/` → `docs/operator/`

`provider_egress_due.yml.example` lived under `beta-vault/config/`. It is the only `.yml.example` in the tree, nothing in the repo references it, and the directory names one specific deployment.

It also implied the wrong install location, twice over: the file is read via `server.Config.SimpleResource("provider_egress_due.yml")` ([provider_egress_location_handlers.go:177](https://github.com/urnetwork/server/blob/main/api/handlers/provider_egress_location_handlers.go#L177)), and `server.Config` is `NewResolver(MOUNT_TYPE_CONFIG)` — so it resolves against the **config** home (`$WARP_CONFIG_HOME`, else `$WARP_HOME/config`), not the vault at all.

Moved to `docs/operator/` beside `prober-systemd.md`, with the real config-home path written into the file. The default-sizing note no longer describes the fallback of 500 in terms of one deployment's fleet.

### Verification

`gofmt` clean on both touched Go files, and the diff contains **zero non-comment code lines**:

```
git diff -- '*.go' | grep -E '^[+-]' | grep -vE '^[+-]{3}' | grep -vE '^[+-]\s*(//|--)'
(no output)
```

A full `go build` was not run here: this checkout lacks the `../proxy`, `../sdk` and `../sn` siblings the module's replace directives need. Given the change is comments plus a file move, parse-and-format checking is the meaningful gate.

### Not addressed here

`model/geolocation_source_pin_model_test.go` accepts `urnetwork-operator-proxy` as a checkout directory name alongside `operator-proxy`. That is a deliberate fallback for checkouts predating the rename and the comment says so, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
