### PR TITLE
ci: add a build, vet and test-compile workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+name: test
+
+# Every branch, deliberately. Work on this project happens on long-lived
+# branches and forks as well as main, and listing them here would bake one
+# repository's layout into a file that is meant to stay identical wherever
+# it is merged. The concurrency group below keeps a busy branch to a single
+# run at a time.
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: server
+
+      # Every github.com/urnetwork/* dependency resolves through a `replace
+      # ../` directive (see go.mod), so a lone checkout does not build: it
+      # fails with "missing go.sum entry", which names nothing about the real
+      # cause. All seven siblings must sit beside the checkout, under exactly
+      # these directory names.
+      #
+      # Tracking each sibling's default branch would make this repo's CI a
+      # function of six other repos' latest commits -- one unrelated push
+      # there turns every open PR here red at once. They are checked out at
+      # their default branch for now, which is the same thing a developer
+      # gets following the README; if that proves too noisy, pin `ref:` per
+      # sibling and bump deliberately.
+      - uses: actions/checkout@v4
+        with: { repository: urnetwork/connect, path: connect }
+      - uses: actions/checkout@v4
+        with: { repository: urnetwork/glog, path: glog }
+      - uses: actions/checkout@v4
+        with: { repository: urnetwork/sdk, path: sdk }
+      - uses: actions/checkout@v4
+        with: { repository: urnetwork/proxy, path: proxy }
+      - uses: actions/checkout@v4
+        with: { repository: urnetwork/goidenticons, path: goidenticons }
+      - uses: actions/checkout@v4
+        with: { repository: urnetwork/userwireguard, path: userwireguard }
+      - uses: actions/checkout@v4
+        with: { repository: urfoundation/sn, path: sn }
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
+      - name: Build
+        working-directory: server
+        run: go build ./...
+
+      - name: Vet
+        working-directory: server
+        run: go vet ./...
+
+      # Compiles every test binary without running any of them. The suite
+      # proper needs postgres and redis (see server.DefaultTestEnv), which
+      # this job deliberately does not stand up -- but a test file that no
+      # longer compiles is a break worth catching on every PR, and it is the
+      # failure that actually happens when a model signature changes.
+      - name: Compile tests
+        working-directory: server
+        run: go test -run 'XXX_NO_SUCH_TEST' -count=1 ./...


### PR DESCRIPTION
This repository has no CI, so a change that breaks the build — or leaves a test file that no longer compiles — is currently only discovered by whoever pulls next. One workflow file, nothing else.

### The part that matters: the sibling checkout

Every `github.com/urnetwork/*` dependency resolves through a `replace ../` directive in [go.mod](https://github.com/urnetwork/server/blob/main/go.mod), so a lone checkout does not build. It fails with:

```
missing go.sum entry for module providing package ...
```

which names nothing about the real cause. The workflow checks out all seven siblings — `connect`, `glog`, `sdk`, `proxy`, `goidenticons`, `userwireguard`, and `urfoundation/sn` — beside the tree, under exactly the directory names the replace directives expect. That is also the layout a developer needs locally, so the workflow doubles as executable documentation of it.

### What it runs

| step | why |
|---|---|
| `go build ./...` | the baseline |
| `go vet ./...` | catches the printf/lock/copy classes cheaply |
| `go test -run 'XXX_NO_SUCH_TEST' -count=1 ./...` | compiles every test binary without running any test |

**It deliberately does not run the suite.** `server.DefaultTestEnv` expects postgres and redis, and standing those up (plus the `WARP_ENV` / `WARP_SERVICE` wiring `test.sh` exports) is a bigger change than this one and not something I could verify end to end here. Compiling the test binaries is the part that stays green without infrastructure while still catching the break that actually happens in practice — a model or handler signature changing out from under a test file. Running the suite for real is a natural follow-up.

### Notes

- **Triggers on every branch**, not a named list, so the file stays byte-identical wherever it is merged rather than baking one repository's branch layout into a shared file. `concurrency` with `cancel-in-progress` keeps a busy branch to one run at a time.
- `permissions: contents: read` and `timeout-minutes: 30` are set explicitly rather than inherited.
- Siblings are checked out at their default branch. That does mean an unrelated push to `connect` can turn this red; if that proves noisy, the fix is to pin `ref:` per sibling and bump deliberately. I left them unpinned so the signal matches what a developer actually gets.

### Verification

Every step was run locally against this tree with all seven siblings present (Go 1.26.5): `go build ./...`, `go vet ./...`, and the test-compile step all pass. The workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
