### PR TITLE
revert(jwt): restore the 30-day token lifetime

### DIFF
--- a/jwt/by_jwt.go
+++ b/jwt/by_jwt.go
@@ -31,10 +31,29 @@ var byJwtTlsKeyPaths = sync.OnceValue(func() []string {
 })
 
 const (
-	// A one-day credential bounds stale authorization even when a client stays
-	// online indefinitely. SDK APIs refresh at half-life and retry before this
-	// deadline, so conforming clients rotate without a protocol change.
-	expiryDuration = 24 * time.Hour
+	// Reverted from 24h to 30 days by team decision.
+	//
+	// The one-day value bounded stale authorization for a client that stays
+	// online indefinitely, which is a real thing to want. It rested on
+	// "conforming clients rotate at half-life" -- and that is true of the sdk
+	// only since the half-life refresh landed on 2026-08-06. It is not true of
+	// anything else holding a token: an app build older than that, or any client
+	// issued a token it does not refresh.
+	//
+	// Those clients do not fail loudly at the deadline. They stay connected and
+	// keep accepting connections while carrying nothing, so they look healthy
+	// from every angle except an egress probe. Measured on beta: 95% probe
+	// success under 12h of client age, 14% at 20-24h, and 0% past 24h across 270
+	// attempts -- a fleet-wide blackhole on a 24h clock, invisible to everything
+	// that was not probing egress.
+	//
+	// 30 days does not fix the non-refreshing client, it only makes the deadline
+	// rare enough to notice. The durable protections are elsewhere and stay in
+	// place: the sdk's half-life rotation, and the server refusing to advertise
+	// a provider whose egress health has aged out (ProviderEgressHealthMaxAge).
+	// Shortening this again should wait until a client that ignores the deadline
+	// is the exception rather than the rule.
+	expiryDuration = 30 * 24 * time.Hour
 	clockLeeway    = 30 * time.Second
 
 	ByJwtIssuer          = "urnetwork:byjwt"

--- a/jwt/by_jwt_test.go
+++ b/jwt/by_jwt_test.go
@@ -112,10 +112,14 @@ func TestByJwtRegisteredClaimsAreEnforced(t *testing.T) {
 	})
 }
 
-func TestByJwtLifetimeIsOneDay(t *testing.T) {
+// The lifetime is asserted rather than assumed because clients schedule their
+// own rotation against it, and the two have already fallen out of step once: a
+// move to 24h left every non-refreshing client silently dark after a day, while
+// staying connected and accepting traffic it could not carry.
+func TestByJwtLifetimeIsThirtyDays(t *testing.T) {
 	claims := NewByJwt(server.NewId(), server.NewId(), "test", false, false)
 	lifetime := claims.ExpiresAt.Time.Sub(claims.IssuedAt.Time)
-	connect.AssertEqual(t, lifetime, 24*time.Hour)
+	connect.AssertEqual(t, lifetime, 30*24*time.Hour)
 }
 
 // TestByJwtKid covers the `kid` key-selection behavior: a freshly signed token


### PR DESCRIPTION
Reverts `expiryDuration` from 24h back to 30 days, per team decision. Already deployed and running on beta.

## Why

The one-day value bounded stale authorization for a client that stays online indefinitely, which is a real thing to want. It rested on a premise stated in its own comment — *"SDK APIs refresh at half-life and retry before this deadline, so conforming clients rotate without a protocol change."*

That premise holds for the sdk **only since the half-life refresh landed on 2026-08-06** ([urnetwork/sdk `8ed3101`](https://github.com/urnetwork/sdk)). It does not hold for anything else holding a token: an app build older than that, or any client issued a token it never refreshes.

## What that looked like in production

A non-refreshing client does not fail loudly at the deadline. It stays connected, keeps accepting connections, and carries nothing — healthy from every angle except an egress probe.

Measured on beta, probe success by client age at probe time:

| provider age when probed | attempts | success |
|---|---|---|
| under 6h | 960 | **95%** |
| 6–12h | 1,610 | **95%** |
| 12–20h | 224 | 58% |
| 20–24h | 266 | 14% |
| 24–30h | 104 | **0%** |
| over 30h | 166 | **0%** |

A fleet-wide blackhole on a 24h clock — 270 consecutive failures past the deadline, and invisible to everything that was not probing egress. It was diagnosed only because a probe asked providers to actually carry traffic.

## What this does and does not fix

**It does not repair anything on its own.** A token already issued keeps its original expiry, so a client that has gone dark stays dark until it re-authenticates. The longer lifetime applies only to tokens minted from here.

**Nor does it fix the non-refreshing client.** It makes the deadline rare enough to be noticed rather than routine.

The durable protections are elsewhere and stay in place:
- the sdk's half-life rotation, for clients that run it;
- the server refusing to advertise a provider whose egress health has aged out (`ProviderEgressHealthMaxAge`, #433).

Shortening this again is reasonable once a client that ignores the deadline is the exception rather than the rule — the comment on the constant says so, so the next person to consider it has the context that was missing this time.

## The test

`TestByJwtLifetimeIsOneDay` is updated rather than deleted, and now records *why* it asserts a value at all: clients schedule their own rotation against this number, and the two have already fallen out of step once.

## Verification

`go build ./jwt/... ./model/... ./api/...`, `go vet ./jwt/`, `gofmt -l` clean, and `go test ./jwt/` passes against a live postgres. Running on beta since deploy — a token minted through `/auth/login` comes back with a 30.0 day lifetime.
