### PR TITLE
feat(model,api): hourly blackhole check, separate from egress health

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -72,6 +72,8 @@ func Routes() []*router.Route {
 		router.NewRoute("POST", "/network/remove-clients", handlers.RemoveNetworkClients),
 		router.NewRoute("POST", "/network/provider-egress-location", handlers.ProviderEgressLocationSubmit),
 		router.NewRoute("GET", "/network/provider-egress-due", handlers.ProviderEgressLocationDue),
+		router.NewRoute("GET", "/network/provider-blackhole-due", handlers.ProviderBlackholeCheckDue),
+		router.NewRoute("POST", "/network/provider-blackhole-checks", handlers.SubmitProviderBlackholeChecks),
 		router.NewRoute("POST", "/network/provider-egress-attempt", handlers.ProviderEgressLocationAttempt),
 		// operator-to-server, same operator secret: the certificate pins this
 		// server observed DIRECTLY for the geolocation source hosts. The

--- a/api/handlers/provider_blackhole_check_handlers.go
+++ b/api/handlers/provider_blackhole_check_handlers.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/model"
+)
+
+const (
+	// defaultProviderBlackholeDueLimit is a batch when the caller names none.
+	// Larger than the egress-location default because a blackhole check is a
+	// single request through an already-required tunnel rather than a ~131
+	// destination sweep -- the whole point is that a batch of these is cheap.
+	defaultProviderBlackholeDueLimit = 500
+	// maxProviderBlackholeDueLimit caps one batch. The sweep is meant to cover
+	// the fleet hourly, so this is sized to let a deployment do that in a few
+	// requests rather than hundreds.
+	maxProviderBlackholeDueLimit = 5000
+)
+
+// ProviderBlackholeCheckDueResult is the response body of
+// ProviderBlackholeCheckDue.
+type ProviderBlackholeCheckDueResult struct {
+	ClientIds []server.Id `json:"client_ids"`
+}
+
+// ProviderBlackholeCheckDue serves the sweep: which providers to check next,
+// never-checked first, then least recently checked.
+//
+// Authenticated with the same operator secret as the egress-location
+// endpoints -- one secret, one mechanism, one thing for a deployment to get
+// right.
+func ProviderBlackholeCheckDue(w http.ResponseWriter, r *http.Request) {
+	secret := operatorIngestSecret()
+	provided := r.Header.Get(operatorSecretHeader)
+	if secret == "" || provided == "" || !hmac.Equal([]byte(secret), []byte(provided)) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	limit := defaultProviderBlackholeDueLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			// not clamped up to 1: limit=0 returns an empty list, which the
+			// caller cannot tell apart from "nothing is due"
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		limit = min(parsed, maxProviderBlackholeDueLimit)
+	}
+
+	shardCount := 1
+	shardIndex := 0
+	if raw := r.URL.Query().Get("shard_count"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		shardCount = parsed
+	}
+	if raw := r.URL.Query().Get("shard_index"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		// an out-of-range index returns nothing forever, which looks exactly
+		// like "the fleet is fully checked" -- reject it instead
+		if err != nil || parsed < 0 || shardCount <= parsed {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		shardIndex = parsed
+	}
+
+	// computed here and passed in: checked_at is a naive timestamp holding utc,
+	// so comparing it to sql now() in the query would cast through the session
+	// timezone
+	minCheckedAt := server.NowUtc().Add(-model.ProviderBlackholeCheckDueAge)
+
+	result := &ProviderBlackholeCheckDueResult{
+		ClientIds: model.GetProviderBlackholeCheckDue(
+			r.Context(),
+			minCheckedAt,
+			limit,
+			shardIndex,
+			shardCount,
+		),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+// SubmitProviderBlackholeCheckArgs is one provider's result. Kept to the single
+// question the check answers: did anything get through.
+type SubmitProviderBlackholeCheckArgs struct {
+	ClientId server.Id `json:"client_id"`
+	OK       bool      `json:"ok"`
+	// Failure is a short class when OK is false: tunnel_failed,
+	// all_destinations_failed, and so on. Ignored when OK.
+	Failure   string    `json:"failure,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// SubmitProviderBlackholeChecks accepts a BATCH of results.
+//
+// Batched, unlike the egress-location submission, because the sweep produces
+// hundreds of one-bit answers per pass and a request each would spend more on
+// http than on the checks themselves.
+type SubmitProviderBlackholeChecksArgs struct {
+	Checks []SubmitProviderBlackholeCheckArgs `json:"checks"`
+}
+
+// maxProviderBlackholeChecksPerRequest bounds one batch, so a malformed or
+// hostile body cannot make the server hold an unbounded slice. It is above
+// maxProviderBlackholeDueLimit so a caller can always report a full batch it
+// was legitimately handed.
+const maxProviderBlackholeChecksPerRequest = 10000
+
+func SubmitProviderBlackholeChecks(w http.ResponseWriter, r *http.Request) {
+	secret := operatorIngestSecret()
+	provided := r.Header.Get(operatorSecretHeader)
+	if secret == "" || provided == "" || !hmac.Equal([]byte(secret), []byte(provided)) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var args SubmitProviderBlackholeChecksArgs
+	if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+	if len(args.Checks) == 0 {
+		http.Error(w, "Missing checks.", http.StatusBadRequest)
+		return
+	}
+	if maxProviderBlackholeChecksPerRequest < len(args.Checks) {
+		http.Error(w, "Too many checks.", http.StatusBadRequest)
+		return
+	}
+
+	now := server.NowUtc()
+
+	// Validate the WHOLE batch before writing any of it. A partial write would
+	// leave the caller unable to tell which results landed, and it reports
+	// fire-and-forget.
+	for _, check := range args.Checks {
+		if check.ClientId == (server.Id{}) {
+			http.Error(w, "Missing client_id.", http.StatusBadRequest)
+			return
+		}
+		if check.CheckedAt.IsZero() {
+			// never fabricated here: an "as of now" timestamp would defeat the
+			// freshness bound the gate depends on, and could pin a stale answer
+			http.Error(w, "Missing checked_at.", http.StatusBadRequest)
+			return
+		}
+		// a future-dated check would outlive every real one under the monotonic
+		// upsert and could never be corrected
+		if now.Add(time.Minute).Before(check.CheckedAt) {
+			http.Error(w, "checked_at is in the future.", http.StatusBadRequest)
+			return
+		}
+		if model.MaxProviderBlackholeFailureLen < len(check.Failure) {
+			http.Error(w, "Failure class too long.", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(check.Failure) == "" && !check.OK {
+			http.Error(w, "A failed check must name a failure class.", http.StatusBadRequest)
+			return
+		}
+	}
+
+	for _, check := range args.Checks {
+		model.SetProviderBlackholeCheck(r.Context(), &model.ProviderBlackholeCheck{
+			ClientId:  check.ClientId,
+			CheckedAt: check.CheckedAt,
+			OK:        check.OK,
+			Failure:   check.Failure,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct{}{})
+}

--- a/db_migrations.go
+++ b/db_migrations.go
@@ -5678,6 +5678,49 @@ var migrations = []any{
 			)
 	`),
 
+	// Blackhole detection is a SEPARATE signal from egress health, not a cheaper
+	// version of it.
+	//
+	// Egress health samples ~131 destinations across several classes and takes
+	// minutes per provider, so it can only sweep the fleet slowly -- on beta a
+	// provider went days between measurements. A provider that stops carrying
+	// traffic is invisible for that whole window: it stays connected, keeps
+	// accepting clients, and answers nothing. This table holds the cheap answer
+	// to the single question "did ANY traffic get through" -- cheap enough to
+	// sweep the whole fleet hourly -- so a provider that goes dark leaves the
+	// public list within hours instead of within days. See
+	// ProviderBlackholeCheckMaxAge for the tolerance that gives the sweep three
+	// attempts at a provider before its evidence lapses.
+	//
+	// One row per provider, keyed on client_id like provider_egress_health: this
+	// is the current picture, not a history. `failure` is a short class, the same
+	// shape and width as provider_egress_probe_attempt.probe_failure, so the
+	// server can reject an oversized value rather than silently truncating it.
+	//
+	// NOTE ON POSITION: this entry is placed before the competition control-plane
+	// block rather than at the end of the list. ApplyDbMigrationsUpTo iterates
+	// `for i := DbVersion(ctx); i < upTo; i += 1`, so a migration runs only when
+	// its list INDEX is at or past the deployed version -- a database already
+	// past this index skips it. Hence IF NOT EXISTS on both statements: they have
+	// to be safe to apply out of band and safe to re-apply.
+	newSqlMigration(`
+        CREATE TABLE IF NOT EXISTS provider_blackhole_check (
+            client_id uuid NOT NULL,
+            checked_at timestamp NOT NULL,
+            ok bool NOT NULL,
+            failure varchar(64) NOT NULL DEFAULT '',
+            update_time timestamp NOT NULL,
+
+            PRIMARY KEY (client_id)
+        );
+
+        -- the due query orders by "checked least recently first", and the sweep
+        -- has to find the oldest rows without scanning the whole table once the
+        -- fleet is large
+        CREATE INDEX IF NOT EXISTS provider_blackhole_check_checked_at
+            ON provider_blackhole_check (checked_at ASC, client_id ASC)
+    `),
+
 	// Durable sim-latency competition control plane. The queue is deliberately
 	// independent of pending_task: untrusted submissions are claimed by a
 	// dedicated evaluator identity, and the singleton slot below makes the FIFO

--- a/model/network_client_location_model.go
+++ b/model/network_client_location_model.go
@@ -1950,12 +1950,18 @@ func providerEgressTestEnabledFromResource(resource *server.SimpleResource, err 
 type providerCountFilter struct {
 	healthCounts map[server.Id]ProviderEgressHealthCounts
 	countryCodes map[server.Id]string
+	// blackholed is the FAILING set only, not a verdict for every provider:
+	// absent means "no current evidence this provider is dark", which covers
+	// both a passing check and no check at all. See
+	// GetAllProviderBlackholedClientIds for why it fails in that direction.
+	blackholed map[server.Id]bool
 }
 
 func newProviderCountFilter(ctx context.Context) providerCountFilter {
 	return providerCountFilter{
 		healthCounts: GetAllProviderEgressHealthCounts(ctx),
 		countryCodes: GetAllProviderEgressCountryCodes(ctx),
+		blackholed:   GetAllProviderBlackholedClientIds(ctx),
 	}
 }
 
@@ -1967,6 +1973,17 @@ func newProviderCountFilter(ctx context.Context) providerCountFilter {
 // Compared exactly as 10*ok >= 9*total rather than through a float, so the 90%
 // boundary cannot drift with rounding.
 func (f providerCountFilter) passesHealth(clientId server.Id) bool {
+	// The hourly blackhole check overrides a passing health measurement, and
+	// only ever in the removing direction. The two run on very different
+	// cadences -- health sweeps the fleet over hours to days, the blackhole
+	// check over an hour -- so a provider that went dark since its last health
+	// measurement is caught here rather than at the next health sweep. A
+	// provider is only in this set when a CURRENT check says nothing got
+	// through; see GetAllProviderBlackholedClientIds.
+	if f.blackholed[clientId] {
+		return false
+	}
+
 	counts, ok := f.healthCounts[clientId]
 	if !ok {
 		return false

--- a/model/provider_blackhole_check_model.go
+++ b/model/provider_blackhole_check_model.go
@@ -1,0 +1,269 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/urnetwork/server"
+)
+
+// ProviderBlackholeCheckMaxAge is how long a blackhole check is treated as
+// current. Past it the provider is indistinguishable from one never checked.
+//
+// This is deliberately short. The whole point of the check is that it is cheap
+// enough to run hourly across the entire fleet, so evidence should never BE
+// this old in a healthy deployment -- if it is, the sweep is not keeping up and
+// the provider should fall back to being judged on egress health alone rather
+// than on a stale liveness answer.
+//
+// 3h, not 1h, so a single missed or slow sweep does not evict the fleet: the
+// checker gets three attempts at a provider before its evidence lapses.
+const ProviderBlackholeCheckMaxAge = 3 * time.Hour
+
+// ProviderBlackholeCheckDueAge is how old a check must be before the provider
+// is offered up again. Half the max age, for the same reason
+// providerEgressDueAge is half ProviderEgressLocationMaxAge: the sweep gets a
+// full window to refresh a check before it expires.
+const ProviderBlackholeCheckDueAge = ProviderBlackholeCheckMaxAge / 2
+
+// MaxProviderBlackholeFailureLen mirrors the failure column width. A submission
+// longer than this is rejected rather than truncated, so a caller learns its
+// class name does not fit instead of having it silently mangled.
+const MaxProviderBlackholeFailureLen = 64
+
+// ProviderBlackholeCheck is the answer to one question, asked of one provider:
+// did ANY traffic get through.
+//
+// It is not a measurement of quality and must not be treated as one. Egress
+// health samples ~131 destinations and can say "this provider resolves names
+// and carries bytes but is refused by content providers"; this says only
+// "something got through" or "nothing did". The two are kept in separate tables
+// because they answer different questions on different cadences, and folding
+// this into provider_egress_health would overwrite a rich per-class measurement
+// with a two-destination sample every hour.
+type ProviderBlackholeCheck struct {
+	ClientId  server.Id
+	CheckedAt time.Time
+	OK        bool
+	// Failure is "" when OK, otherwise a short class such as tunnel_failed or
+	// all_destinations_failed.
+	Failure    string
+	UpdateTime time.Time
+}
+
+// SetProviderBlackholeCheck upserts the latest check for a provider.
+//
+// The upsert is monotonic in checked_at, like SetProviderEgressLocation and
+// SetProviderEgressProbeAttempt: a replayed or out-of-order report older than
+// what is stored is dropped rather than moving the provider's last-checked time
+// backwards, which would hand it straight back to the sweep.
+func SetProviderBlackholeCheck(ctx context.Context, c *ProviderBlackholeCheck) {
+	failure := c.Failure
+	if c.OK {
+		// a successful check has nothing to explain, and storing a failure class
+		// beside ok=true would leave two contradictory answers in one row
+		failure = ""
+	}
+
+	server.Tx(ctx, func(tx server.PgTx) {
+		server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+			INSERT INTO provider_blackhole_check (
+				client_id,
+				checked_at,
+				ok,
+				failure,
+				update_time
+			)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (client_id) DO UPDATE
+			SET
+				checked_at = $2,
+				ok = $3,
+				failure = $4,
+				update_time = $5
+			WHERE provider_blackhole_check.checked_at < EXCLUDED.checked_at
+			`,
+			c.ClientId,
+			c.CheckedAt.UTC(),
+			c.OK,
+			failure,
+			server.NowUtc(),
+		))
+	})
+}
+
+// GetProviderBlackholeCheck returns the latest check for a provider, or nil
+// when it has never been checked. Never checked is not the same as checked-bad,
+// so it is a nil result rather than a zero-valued one.
+func GetProviderBlackholeCheck(ctx context.Context, clientId server.Id) *ProviderBlackholeCheck {
+	var c *ProviderBlackholeCheck
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+			SELECT client_id, checked_at, ok, failure, update_time
+			FROM provider_blackhole_check
+			WHERE client_id = $1
+			`,
+			clientId,
+		)
+		server.WithPgResult(result, err, func() {
+			if result.Next() {
+				c = &ProviderBlackholeCheck{}
+				server.Raise(result.Scan(
+					&c.ClientId,
+					&c.CheckedAt,
+					&c.OK,
+					&c.Failure,
+					&c.UpdateTime,
+				))
+			}
+		})
+	})
+	return c
+}
+
+// GetAllProviderBlackholedClientIds returns the providers whose most recent
+// check says nothing got through, bounded to checks still considered current.
+//
+// It returns the FAILING set rather than a map of every provider, because that
+// is what the gate needs and the failing set is the small one: in a healthy
+// fleet almost every check passes, so loading only the failures keeps this
+// proportional to the problem rather than to the population.
+//
+// A stale check is omitted, which means the provider is NOT treated as
+// blackholed. That is the deliberate direction to fail: this signal can only
+// ever remove providers from the list, so when its evidence lapses the provider
+// falls back to being judged on egress health alone. The alternative -- treating
+// "we have not checked recently" as "blackholed" -- would empty the list the
+// moment the sweep stalled, which is exactly the failure the count gate's
+// fleet-wide floor exists to prevent.
+func GetAllProviderBlackholedClientIds(ctx context.Context) map[server.Id]bool {
+	blackholed := map[server.Id]bool{}
+
+	minCheckedAt := server.NowUtc().Add(-ProviderBlackholeCheckMaxAge)
+
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+			SELECT client_id
+			FROM provider_blackhole_check
+			WHERE
+				ok = false AND
+				checked_at >= $1
+			`,
+			minCheckedAt.UTC(),
+		)
+		server.WithPgResult(result, err, func() {
+			for result.Next() {
+				var clientId server.Id
+				server.Raise(result.Scan(&clientId))
+				blackholed[clientId] = true
+			}
+		})
+	})
+
+	return blackholed
+}
+
+// GetProviderBlackholeCheckDue returns the providers to check next: those never
+// checked, then those checked least recently, oldest first.
+//
+// The candidate set is the same "can this provider serve a stranger" predicate
+// the egress-location queue uses -- connected, valid, and holding a Public
+// provide key. A provider that cannot accept a contract cannot be checked, and
+// offering it would burn a slot on a tunnel that will be refused.
+//
+// Unlike the egress-location queue this has no attempt backoff. The check is
+// cheap and the whole design is that it runs hourly over everything, so a
+// provider that failed last hour must be re-checked this hour -- that is how it
+// gets back into the list once it recovers. Rate limiting belongs in the
+// sweep's own cadence, not in a per-provider deferral here.
+func GetProviderBlackholeCheckDue(
+	ctx context.Context,
+	minCheckedAt time.Time,
+	limit int,
+	shardIndex int,
+	shardCount int,
+) []server.Id {
+	clientIds := []server.Id{}
+
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+			SELECT
+				network_client_location_reliability.client_id
+			FROM network_client_location_reliability
+
+			LEFT JOIN provider_blackhole_check ON
+				provider_blackhole_check.client_id = network_client_location_reliability.client_id
+
+			WHERE
+				network_client_location_reliability.connected = true AND
+				network_client_location_reliability.valid = true AND
+				EXISTS (
+					SELECT 1 FROM provide_key
+					WHERE
+						provide_key.client_id = network_client_location_reliability.client_id AND
+						provide_key.provide_mode = $1
+				) AND
+				(
+					provider_blackhole_check.client_id IS NULL OR
+					provider_blackhole_check.checked_at < $2
+				) AND
+				-- the same shard partition the egress-location queue uses.
+				-- hashtext returns a SIGNED int32 and postgres '%' keeps the sign
+				-- of the dividend, so a bare hashtext(...) % n = i never matches
+				-- the negative half of the hash space and roughly half the fleet
+				-- would never be checked. The extra (+ n) % n normalises into
+				-- [0, n). $4 <= 1 short-circuits to the unsharded behaviour.
+				(
+					$4 <= 1 OR
+					((hashtext(network_client_location_reliability.client_id::text) % $4) + $4) % $4 = $5
+				)
+
+			-- never checked first (NULL sorts first here), then least recently
+			-- checked; client_id breaks the tie so batch composition is
+			-- deterministic rather than plan-dependent
+			ORDER BY
+				provider_blackhole_check.checked_at ASC NULLS FIRST,
+				network_client_location_reliability.client_id ASC
+			LIMIT $3
+			`,
+			ProvideModePublic,
+			minCheckedAt.UTC(),
+			limit,
+			shardCount,
+			shardIndex,
+		)
+		server.WithPgResult(result, err, func() {
+			for result.Next() {
+				var clientId server.Id
+				server.Raise(result.Scan(&clientId))
+				clientIds = append(clientIds, clientId)
+			}
+		})
+	})
+
+	return clientIds
+}
+
+// RemoveExpiredProviderBlackholeChecks drops checks older than minCheckedAt, so
+// the table tracks the live population rather than growing without bound as
+// providers come and go.
+func RemoveExpiredProviderBlackholeChecks(ctx context.Context, minCheckedAt time.Time) {
+	server.Tx(ctx, func(tx server.PgTx) {
+		server.RaisePgResult(tx.Exec(
+			ctx,
+			`
+			DELETE FROM provider_blackhole_check
+			WHERE checked_at < $1
+			`,
+			minCheckedAt.UTC(),
+		))
+	})
+}

--- a/model/provider_blackhole_check_model_test.go
+++ b/model/provider_blackhole_check_model_test.go
@@ -1,0 +1,170 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/urnetwork/connect"
+
+	"github.com/urnetwork/server"
+)
+
+// A current failing check must override a passing health measurement.
+//
+// This is the whole reason the check exists. Egress health sweeps the fleet
+// over hours to days, so a provider that goes dark keeps its passing tally --
+// and its place in the public list -- until the next sweep reaches it. The
+// hourly check closes that window.
+func TestBlackholedProviderFailsTheHealthGate(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+		now := server.NowUtc()
+
+		healthy := server.NewId()
+		blackholed := server.NewId()
+
+		for _, clientId := range []server.Id{healthy, blackholed} {
+			SetProviderEgressHealth(ctx, &ProviderEgressHealth{
+				ClientId:   clientId,
+				MeasuredAt: now.Add(-time.Hour),
+				OKCount:    100, Total: 100,
+			})
+		}
+
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId: blackholed, CheckedAt: now.Add(-time.Minute),
+			OK: false, Failure: "all_destinations_failed",
+		})
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId: healthy, CheckedAt: now.Add(-time.Minute), OK: true,
+		})
+
+		f := newProviderCountFilter(ctx)
+
+		if !f.passesHealth(healthy) {
+			t.Errorf("a provider measured healthy and checked ok must pass the gate")
+		}
+		if f.passesHealth(blackholed) {
+			t.Errorf("a provider whose current check says nothing got through must NOT pass the gate, " +
+				"even with a passing health measurement -- that combination is exactly a provider that went dark since it was last swept")
+		}
+	})
+}
+
+// A check that has aged out must NOT be read as "blackholed".
+//
+// The signal can only ever remove providers, so when its evidence lapses the
+// provider falls back to being judged on egress health alone. Treating "not
+// checked recently" as "dark" would empty the list the moment the sweep
+// stalled.
+func TestStaleBlackholeCheckDoesNotExclude(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+		now := server.NowUtc()
+
+		clientId := server.NewId()
+		SetProviderEgressHealth(ctx, &ProviderEgressHealth{
+			ClientId:   clientId,
+			MeasuredAt: now.Add(-time.Hour),
+			OKCount:    100, Total: 100,
+		})
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId:  clientId,
+			CheckedAt: now.Add(-ProviderBlackholeCheckMaxAge - time.Minute),
+			OK:        false, Failure: "all_destinations_failed",
+		})
+
+		if !newProviderCountFilter(ctx).passesHealth(clientId) {
+			t.Errorf("a failing check older than %s must not keep excluding the provider: "+
+				"a stalled sweep would otherwise drain the list", ProviderBlackholeCheckMaxAge)
+		}
+	})
+}
+
+// The upsert is monotonic: an out-of-order or replayed report must not move a
+// provider's last-checked time backwards, which would hand it straight back to
+// the sweep and, worse, could resurrect a stale verdict over a current one.
+func TestSetProviderBlackholeCheckIsMonotonic(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+		now := server.NowUtc()
+		clientId := server.NewId()
+
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId: clientId, CheckedAt: now.Add(-time.Minute), OK: true,
+		})
+		// an older report arriving late
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId: clientId, CheckedAt: now.Add(-time.Hour),
+			OK: false, Failure: "tunnel_failed",
+		})
+
+		c := GetProviderBlackholeCheck(ctx, clientId)
+		connect.AssertNotEqual(t, c, nil)
+		if !c.OK {
+			t.Errorf("a report older than the stored one overwrote it: ok=%v failure=%q checked_at=%s",
+				c.OK, c.Failure, c.CheckedAt)
+		}
+	})
+}
+
+// The due query offers never-checked providers first, then the least recently
+// checked, and never offers one checked inside the window.
+func TestGetProviderBlackholeCheckDue(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+		now := server.NowUtc()
+
+		city := &Location{
+			LocationType: LocationTypeCity,
+			City:         "Palo Alto",
+			Region:       "California",
+			Country:      "United States",
+			CountryCode:  "us",
+		}
+		CreateLocation(ctx, city)
+
+		never := server.NewId()
+		stale := server.NewId()
+		fresh := server.NewId()
+
+		testing_connectProbeableProvider(t, ctx, never, city.LocationId, "0.0.0.1:0", ProvideModePublic)
+		testing_connectProbeableProvider(t, ctx, stale, city.LocationId, "0.0.0.2:0", ProvideModePublic)
+		testing_connectProbeableProvider(t, ctx, fresh, city.LocationId, "0.0.0.3:0", ProvideModePublic)
+		UpdateClientLocationReliabilities(ctx, now.Add(-time.Hour), now)
+
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId: stale, CheckedAt: now.Add(-24 * time.Hour), OK: true,
+		})
+		SetProviderBlackholeCheck(ctx, &ProviderBlackholeCheck{
+			ClientId: fresh, CheckedAt: now.Add(-time.Minute), OK: true,
+		})
+
+		due := GetProviderBlackholeCheckDue(ctx, now.Add(-ProviderBlackholeCheckDueAge), 100, 0, 1)
+
+		has := func(id server.Id) bool {
+			for _, d := range due {
+				if d == id {
+					return true
+				}
+			}
+			return false
+		}
+		if !has(never) {
+			t.Errorf("due = %v, must contain the never-checked provider %s", due, never)
+		}
+		if !has(stale) {
+			t.Errorf("due = %v, must contain the provider checked a day ago %s", due, stale)
+		}
+		if has(fresh) {
+			t.Errorf("due = %v, must not contain the provider checked a minute ago %s: "+
+				"re-checking inside the window spends the sweep on providers that do not need it", due, fresh)
+		}
+		// a failing check carries NO backoff -- that is how a recovered provider
+		// gets back into the list -- so ordering is by age alone
+		if 0 < len(due) && due[0] != never {
+			t.Errorf("due[0] = %s, want the never-checked provider %s first", due[0], never)
+		}
+	})
+}


### PR DESCRIPTION
Egress health samples ~131 destinations per provider and sweeps a fleet over hours to days. In that window a provider that stops carrying traffic keeps its last passing measurement and stays in the public list — it remains connected and keeps accepting clients, so nothing else reveals it. On beta, 12 of 12 providers sampled from the stalest cohort answered `ok=0/131` while still advertised.

This adds the cheap complement: one question — did ANY traffic get through — per provider hourly, in its own table. Folding it into `provider_egress_health` would overwrite a per-class measurement whose value is the detail.

The signal only ever REMOVES providers. Only a *current* failing check excludes; a check that has aged out falls back to health alone, so a stalled sweep cannot drain the list.

**Inert on merge:** the table only fills if a sweeper calls the endpoints, and `providerEgressTestEnabled()` defaults false upstream. Nothing changes on mainnet until someone opts in and runs a prober.

**Migration placement — read before merging.** This adds a migration before the competition block. `ApplyDbMigrationsUpTo` iterates `for i := DbVersion(ctx); i < upTo; i += 1`, so on an already-deployed database (version ~586) an entry at a lower index is never reached and the table is not created. Verified on beta and fixed there by running `bringyourctl db audit --fix` after deploy, which emits the `CREATE TABLE`. The statement is `IF NOT EXISTS` so it is safe to apply out of band and safe to re-apply.

Separately: `TestCompetitionMigrationsFollowOriginMigrations` **already fails on pristine `main`** (`index = 578, want suffix index 583`), so it is not a signal introduced here.