### PR TITLE
feat(model): diagnose a probe fleet that is failing wholesale

### DIFF
--- a/model/provider_egress_probe_fleet.go
+++ b/model/provider_egress_probe_fleet.go
@@ -1,0 +1,229 @@
+package model
+
+import (
+	"context"
+	"sort"
+
+	"github.com/urnetwork/server"
+)
+
+// Fleet-wide diagnosis of the probe pipeline.
+//
+// # The incident this exists for
+//
+// A prober whose platform jwt had been rejected reported EVERY provider as
+// `no_consensus` for eight hours. Every individual record was well-formed, every
+// endpoint returned 200, the due queue kept handing out work and the prober kept
+// taking it. Per-provider the data was indistinguishable from a genuinely
+// unreachable fleet, and nothing anywhere said "credential".
+//
+// The tell was only ever visible in aggregate: when essentially every provider
+// fails, and they all fail the SAME way, the one thing they have in common is
+// not the providers -- it is the prober. That is a statement about the
+// distribution of failures, so it cannot be made per submission; it has to be
+// made over the population. This file makes it.
+//
+// # What the table actually holds
+//
+// provider_egress_probe_attempt is upserted per client_id and swept at 4x
+// ProviderEgressProbeAttemptBackoff, so it holds AT MOST ONE ROW PER PROVIDER:
+// that provider's latest attempt. It is a snapshot of the fleet's current
+// state, not an event stream, which is exactly the shape wanted here -- "what
+// is every provider's most recent probe outcome" -- but two consequences follow
+// and must not be "fixed" away:
+//
+//   - A successful attempt stores probe_failure = '' (see
+//     RecordProviderEgressProbeAttempt). The empty class therefore counts the
+//     HEALTHY providers. A dominant-class computation that does a plain argmax
+//     over the tally would diagnose a perfectly healthy fleet as "100% failing
+//     with class ''". ProbeAttemptSuccessClass is excluded for that reason.
+//   - The diagnosis cannot fire the instant an incident begins. The table starts
+//     out mixed and converges as providers are re-attempted, which at a 6h
+//     backoff takes a few hours -- comfortably inside the eight-hour incident,
+//     but it means this is a trend detector and not a trip wire. Do not convert
+//     it into a per-request trigger to make it faster; a single failing
+//     submission carries no fleet-wide information at all.
+
+// ProbeAttemptSuccessClass is the probe_failure value stored for an attempt
+// that SUCCEEDED. It is the empty string because the column is NOT NULL and a
+// success has no failure to name.
+const ProbeAttemptSuccessClass = ""
+
+// MinProbeFleetDiagnosisAttempts is the floor on how many providers must have a
+// recorded attempt before any fleet-wide diagnosis is made.
+//
+// Without a floor this is a wolf-crier. A cold deployment whose first three
+// probes all failed is at a 100% failure rate with a single dominant class, and
+// warning there would teach operators to ignore the message -- at which point
+// the real incident goes unread too. Three providers failing is not evidence
+// about a fleet; it is evidence about three providers.
+const MinProbeFleetDiagnosisAttempts = 20
+
+// The share of ALL attempts a single failure class must reach before the fault
+// is attributed to the prober. Compared as exact integers
+// (denominator*count >= numerator*attempts) rather than through a float, so the
+// boundary cannot drift with rounding -- the same reason
+// minEgressHealthOKNumerator/Denominator are written this way.
+//
+// The share is deliberately taken over every attempt rather than over the
+// failures alone. "90% of failures are no_consensus" is unremarkable and true
+// in normal operation, because a fleet has a characteristic failure mode. "90%
+// of the entire fleet just failed, all identically" is the incident.
+const (
+	probeFleetFailureShareNumerator   = 9
+	probeFleetFailureShareDenominator = 10
+)
+
+// ProbeFleetDiagnosis is the finding: one failure class accounts for
+// essentially the whole fleet.
+type ProbeFleetDiagnosis struct {
+	// Attempts is every provider with a recorded attempt, successful or not.
+	Attempts int
+	// DominantClass is the failure class covering nearly all of them. Never
+	// ProbeAttemptSuccessClass.
+	DominantClass string
+	// DominantCount is how many providers reported DominantClass.
+	DominantCount int
+	// Hint names the prober-side cause to check first. It is the part the
+	// incident was missing: the operator had the failure class all along and
+	// still had no reason to suspect a credential.
+	Hint string
+}
+
+// probeFleetHint maps a failure class to the prober-side cause worth checking
+// before anyone starts investigating providers.
+//
+// Every hint leads with the prober rather than the fleet, because reaching this
+// function already means the fleet-wide test passed -- the providers have
+// already been ruled out as the common factor by the distribution itself.
+func probeFleetHint(class string) string {
+	switch class {
+	case "no_consensus":
+		// the incident verbatim. no_consensus means the geolocation lookups
+		// never reached agreement, which happens when nothing is carried
+		// through the tunnel at all -- including when no tunnel is ever
+		// established because the prober's own credential was refused
+		return "CREDENTIAL FIRST: the prober's platform jwt (UR_PROBER_BY_JWT) may be expired or " +
+			"rejected, so no tunnel is being established and the geolocation lookups return nothing " +
+			"to agree on. This exact shape was an 8h outage. Check the prober's auth before " +
+			"investigating any provider"
+	case "tunnel_failed", "contract_failed":
+		return "CREDENTIAL FIRST: the prober cannot open a tunnel to ANY provider. Check its " +
+			"platform jwt (UR_PROBER_BY_JWT), then its network's transfer balance -- a prober " +
+			"network with no balance cannot form a contract with anyone"
+	default:
+		return "the common factor across this many providers is the prober, not the providers. " +
+			"Check the prober's credentials, its egress confinement, and its connectivity to the " +
+			"platform before investigating individual providers"
+	}
+}
+
+// DiagnoseProbeFleet decides whether a tally of latest-attempt outcomes says the
+// PROBER is broken rather than the fleet. It returns nil when it does not.
+//
+// Pure: no I/O, no clock, no database. The caller supplies the tally, so the
+// rule is table-testable on its own, which matters because this decides whether
+// a warning is emitted and a warning that never fires is indistinguishable from
+// one that was never written.
+//
+// tally maps probe_failure to the number of providers whose LATEST attempt
+// carried it, including ProbeAttemptSuccessClass for the successes.
+func DiagnoseProbeFleet(tally map[string]int) *ProbeFleetDiagnosis {
+	attempts := 0
+	dominantClass := ""
+	dominantCount := 0
+
+	// sorted so a tie between two equally-sized classes resolves the same way
+	// every time; an unstable diagnosis would flap between two names in the log
+	// and read as two different faults
+	classes := make([]string, 0, len(tally))
+	for class := range tally {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+
+	for _, class := range classes {
+		count := tally[class]
+		if count <= 0 {
+			// a zero or negative bucket is not an observation of anything, and
+			// counting it would drag the denominator around
+			continue
+		}
+		attempts += count
+		// successes are counted into attempts (they are the denominator the
+		// failure share is measured against) but can never BE the dominant
+		// failure class -- see the file comment
+		if class == ProbeAttemptSuccessClass {
+			continue
+		}
+		if dominantCount < count {
+			dominantClass = class
+			dominantCount = count
+		}
+	}
+
+	if attempts < MinProbeFleetDiagnosisAttempts {
+		return nil
+	}
+	if dominantClass == ProbeAttemptSuccessClass {
+		// no failures at all, or only zero-count buckets.
+		//
+		// Deliberately redundant with the ProbeAttemptSuccessClass skip in the
+		// loop above: either one alone is sufficient to keep a healthy fleet
+		// from being diagnosed. Both are kept because the failure they prevent
+		// -- reporting a fleet where every probe SUCCEEDED as one where every
+		// probe failed with class "" -- is the worst possible output of this
+		// function, and it is one deleted `continue` away in a naive rewrite.
+		return nil
+	}
+	if probeFleetFailureShareDenominator*dominantCount < probeFleetFailureShareNumerator*attempts {
+		return nil
+	}
+
+	return &ProbeFleetDiagnosis{
+		Attempts:      attempts,
+		DominantClass: dominantClass,
+		DominantCount: dominantCount,
+		Hint:          probeFleetHint(dominantClass),
+	}
+}
+
+// GetProviderEgressProbeAttemptTally counts providers by the failure class of
+// their most recent probe attempt.
+//
+// One row per provider is already the table's shape (upsert on client_id), so
+// this is a GROUP BY over a few hundred rows and needs no time bound of its own
+// -- RemoveExpiredProviderEgressProbeAttempts keeps the table to the live
+// population.
+func GetProviderEgressProbeAttemptTally(ctx context.Context) map[string]int {
+	tally := map[string]int{}
+
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(
+			ctx,
+			`
+			SELECT
+				probe_failure,
+				COUNT(*)
+			FROM provider_egress_probe_attempt
+			GROUP BY probe_failure
+			`,
+		)
+		server.WithPgResult(result, err, func() {
+			for result.Next() {
+				var probeFailure string
+				var count int
+				server.Raise(result.Scan(&probeFailure, &count))
+				tally[probeFailure] = count
+			}
+		})
+	})
+
+	return tally
+}
+
+// DiagnoseProviderEgressProbeFleet reads the current tally and applies
+// DiagnoseProbeFleet to it. Returns nil when the fleet looks normal.
+func DiagnoseProviderEgressProbeFleet(ctx context.Context) *ProbeFleetDiagnosis {
+	return DiagnoseProbeFleet(GetProviderEgressProbeAttemptTally(ctx))
+}

--- a/model/provider_egress_probe_fleet_test.go
+++ b/model/provider_egress_probe_fleet_test.go
@@ -1,0 +1,285 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/urnetwork/server"
+)
+
+// TestDiagnoseProbeFleet is the pure rule behind the credential warning.
+//
+// It is table-driven and needs no database, which is the point: this decides
+// whether a warning is EMITTED, and a warning that silently never fires is
+// exactly the class of fault this whole exercise is about. Testing the log call
+// is impossible here (nothing in this repo captures glog output), so the
+// decision is a pure function and the glog call is a one-line shell around it.
+//
+// The cases that carry the weight are the negative ones. Any predicate at all
+// fires on "100% no_consensus"; only a correct one stays quiet on a healthy
+// fleet and on a cold deployment.
+func TestDiagnoseProbeFleet(t *testing.T) {
+	cases := []struct {
+		name  string
+		tally map[string]int
+		// wantClass is "" when no diagnosis must be produced.
+		wantClass string
+		why       string
+	}{
+		{
+			name: "the incident: every provider no_consensus",
+			tally: map[string]int{
+				"no_consensus": 152,
+			},
+			wantClass: "no_consensus",
+			why: "a prober whose jwt was rejected reported this shape for 8 hours and nothing " +
+				"said credential; if this case stops producing a diagnosis the warning is gone",
+		},
+		{
+			name: "healthy fleet, every attempt succeeded",
+			tally: map[string]int{
+				ProbeAttemptSuccessClass: 152,
+			},
+			wantClass: "",
+			why: "successes are stored as probe_failure = '', so a NAIVE ARGMAX over the tally " +
+				"calls a perfectly healthy fleet '100% failing with class \"\"'. That is the most " +
+				"likely bug in this function and this case is the only thing standing in front of " +
+				"it. VERIFIED MUTATION: writing the naive argmax -- dropping BOTH the " +
+				"ProbeAttemptSuccessClass skip inside the loop AND the post-loop guard -- makes " +
+				"this case report class=\"\" 152/152. (Either guard alone still returns nil, so " +
+				"they are deliberate defence in depth; removing just one is not enough to break it " +
+				"and is not what this pins.)",
+		},
+		{
+			name: "healthy fleet with an ordinary minority of failures",
+			tally: map[string]int{
+				ProbeAttemptSuccessClass: 140,
+				"no_consensus":           8,
+				"tunnel_failed":          4,
+			},
+			wantClass: "",
+			why: "every fleet has a characteristic failure mode; 8 of 152 is normal operation. " +
+				"MUTATION: measure the dominant share over the FAILURES (8/12) instead of over " +
+				"all attempts (8/152) and this case fires, making the warning constant noise",
+		},
+		{
+			name: "cold deployment: three attempts, all failed",
+			tally: map[string]int{
+				"tunnel_failed": 3,
+			},
+			wantClass: "",
+			why: "3 providers failing is evidence about 3 providers, not about a fleet. " +
+				"MUTATION: set MinProbeFleetDiagnosisAttempts to 0 and this case fires -- the " +
+				"wolf-crier that teaches operators to ignore the message, after which the real " +
+				"incident goes unread too",
+		},
+		{
+			name: "exactly at the sample floor, wholly failing",
+			tally: map[string]int{
+				"no_consensus": MinProbeFleetDiagnosisAttempts,
+			},
+			wantClass: "no_consensus",
+			why:       "the floor is inclusive; at the floor with 100% failure there is a real finding",
+		},
+		{
+			name: "one attempt below the sample floor, wholly failing",
+			tally: map[string]int{
+				"no_consensus": MinProbeFleetDiagnosisAttempts - 1,
+			},
+			wantClass: "",
+			why: "pins the floor's exact boundary; a test only at 3-vs-152 would pass with the " +
+				"floor set to any value in between",
+		},
+		{
+			name: "dominant class at exactly the share threshold",
+			tally: map[string]int{
+				"no_consensus":           90,
+				ProbeAttemptSuccessClass: 10,
+			},
+			wantClass: "no_consensus",
+			why:       "90/100 is exactly 9/10 and the comparison is >=, so this must fire",
+		},
+		{
+			name: "dominant class one below the share threshold",
+			tally: map[string]int{
+				"no_consensus":           89,
+				ProbeAttemptSuccessClass: 11,
+			},
+			wantClass: "",
+			why: "89/100 is under 9/10 and must not fire. With the case above, this pins the " +
+				"boundary exactly -- MUTATION: loosen the ratio to 4/5 and this case starts firing",
+		},
+		{
+			name: "a real fleet outage spread across several classes",
+			tally: map[string]int{
+				"tunnel_failed":   60,
+				"no_consensus":    50,
+				"contract_failed": 42,
+			},
+			wantClass: "",
+			why: "everything is failing but in THREE different ways, so the providers are not " +
+				"failing identically and the prober is not implicated as the single common " +
+				"factor. Diagnosing here would send an operator to check a credential during a " +
+				"genuine fleet-wide outage",
+		},
+		{
+			name:      "empty tally",
+			tally:     map[string]int{},
+			wantClass: "",
+			why:       "nothing has been attempted; there is nothing to conclude",
+		},
+		{
+			name: "zero-count buckets are not observations",
+			tally: map[string]int{
+				"no_consensus":           30,
+				"tunnel_failed":          0,
+				ProbeAttemptSuccessClass: 0,
+			},
+			wantClass: "no_consensus",
+			why: "a zero bucket must not count toward the denominator or become the dominant " +
+				"class; 30/30 is still a complete failure",
+		},
+	}
+
+	for _, c := range cases {
+		got := DiagnoseProbeFleet(c.tally)
+
+		if c.wantClass == "" {
+			if got != nil {
+				t.Errorf("%s: got a diagnosis (class=%q %d/%d), want none\n  %s",
+					c.name, got.DominantClass, got.DominantCount, got.Attempts, c.why)
+			}
+			continue
+		}
+
+		if got == nil {
+			t.Errorf("%s: got no diagnosis, want dominant class %q\n  %s",
+				c.name, c.wantClass, c.why)
+			continue
+		}
+		if got.DominantClass != c.wantClass {
+			t.Errorf("%s: dominant class = %q, want %q\n  %s",
+				c.name, got.DominantClass, c.wantClass, c.why)
+		}
+		// the hint is the part the incident was missing -- the operator had the
+		// failure class the whole time and still had no reason to suspect a
+		// credential. A diagnosis with an empty hint reports the symptom and
+		// withholds the diagnosis.
+		if strings.TrimSpace(got.Hint) == "" {
+			t.Errorf("%s: diagnosis carries no hint; naming the class without naming the "+
+				"likely cause is what left the 8h outage unexplained", c.name)
+		}
+	}
+}
+
+// The two failure classes that mean "the prober never got a tunnel up" must
+// point at credentials explicitly, by name.
+//
+// This is the one assertion that directly encodes "nothing said credential".
+// A generic "something is wrong with probing" hint would satisfy the non-empty
+// check in the table test above while still leaving the operator exactly where
+// the incident left them.
+//
+// MUTATION THAT MUST BREAK THIS: collapse probeFleetHint's switch to its
+// default branch. The word "CREDENTIAL" disappears from the no_consensus and
+// tunnel_failed hints and this fails.
+func TestProbeFleetHintNamesTheCredential(t *testing.T) {
+	for _, class := range []string{"no_consensus", "tunnel_failed", "contract_failed"} {
+		hint := probeFleetHint(class)
+		if !strings.Contains(hint, "CREDENTIAL") {
+			t.Errorf("probeFleetHint(%q) = %q, which never mentions a credential. "+
+				"A prober whose jwt was rejected produces exactly this class fleet-wide, and the "+
+				"operator's 8h of investigation went to the providers because nothing pointed at auth",
+				class, hint)
+		}
+	}
+	// and the fallback still has to say something actionable rather than
+	// nothing, since an unknown class is precisely when an operator has least
+	// to go on
+	if strings.TrimSpace(probeFleetHint("something_new")) == "" {
+		t.Error("an unrecognised failure class must still produce a hint")
+	}
+}
+
+// TestGetProviderEgressProbeAttemptTally pins the query the diagnosis reads.
+//
+// Both halves matter and both are asserted: successes must be tallied under
+// ProbeAttemptSuccessClass (they are what the failure share is measured
+// against, so losing them inflates every ratio to 100%), and failures must be
+// tallied under their own class.
+//
+// MUTATION THAT MUST BREAK THIS: change the GROUP BY to filter out the empty
+// class (`WHERE probe_failure != ”`), which is a plausible "tidy-up". The
+// success bucket vanishes, the assertion below fails -- and had it not, every
+// healthy fleet would have been diagnosed as 100% failing.
+func TestGetProviderEgressProbeAttemptTally(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+		now := server.NowUtc()
+
+		// three failures of one class, two of another, and two successes
+		wrote := map[string]int{
+			"no_consensus":           3,
+			"tunnel_failed":          2,
+			ProbeAttemptSuccessClass: 2,
+		}
+		for class, n := range wrote {
+			for i := 0; i < n; i++ {
+				SetProviderEgressProbeAttempt(ctx, &ProviderEgressProbeAttempt{
+					ClientId:     server.NewId(),
+					AttemptAt:    now,
+					ProbeFailure: class,
+				})
+			}
+		}
+
+		tally := GetProviderEgressProbeAttemptTally(ctx)
+
+		// asserted as ">= what this test wrote" rather than as equality: this
+		// reads the whole table, so an exact count would be a statement about
+		// every other test's fixtures rather than about the grouping
+		for class, n := range wrote {
+			if tally[class] < n {
+				t.Errorf("tally[%q] = %d, want at least the %d this test wrote",
+					class, tally[class], n)
+			}
+		}
+		// called out separately because it is the bucket a "tidy-up" deletes:
+		// successes are stored as probe_failure = '' and are the denominator the
+		// failure share is measured against, so dropping them makes every fleet
+		// look 100% failing
+		if tally[ProbeAttemptSuccessClass] < wrote[ProbeAttemptSuccessClass] {
+			t.Errorf("successful attempts are not tallied under the empty class: "+
+				"tally[%q] = %d. They are the denominator the failure share is measured "+
+				"against, and without them every healthy fleet reads as 100%% failing",
+				ProbeAttemptSuccessClass, tally[ProbeAttemptSuccessClass])
+		}
+	})
+}
+
+// The database-backed diagnosis must agree with the pure rule applied to the
+// same table. This is the seam between the two halves: a query that returned
+// the right rows and a predicate that read them under different key names would
+// leave both unit tests green and the warning permanently silent.
+func TestDiagnoseProviderEgressProbeFleetMatchesTheTally(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		tally := GetProviderEgressProbeAttemptTally(ctx)
+		want := DiagnoseProbeFleet(tally)
+		got := DiagnoseProviderEgressProbeFleet(ctx)
+
+		switch {
+		case want == nil && got != nil:
+			t.Errorf("the db-backed diagnosis produced %+v where the pure rule over the same "+
+				"tally %v produced none", got, tally)
+		case want != nil && got == nil:
+			t.Errorf("the db-backed diagnosis produced nothing where the pure rule over the "+
+				"same tally %v produced %+v", tally, want)
+		case want != nil && got != nil && want.DominantClass != got.DominantClass:
+			t.Errorf("db-backed dominant class = %q, pure rule = %q over tally %v",
+				got.DominantClass, want.DominantClass, tally)
+		}
+	})
+}


### PR DESCRIPTION
Answers the question that cost one deployment eight hours: when every provider comes back failing, is the fleet bad or is the prober's own credential dead? A dominant failure class across the whole fleet is a property of the prober, not of thousands of independent providers.

**Reviewer note, stated plainly: this has no callers yet.** It is the diagnosis primitive; wiring it into the due-queue handler is a follow-up. Hold this one if you would rather it arrive wired.