### PR TITLE
fix: stop wrongly refusing first-time signups, and make the cause loud

### DIFF
--- a/api/handlers/network_create_status_regression_test.go
+++ b/api/handlers/network_create_status_regression_test.go
@@ -1,0 +1,210 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/model"
+	"github.com/urnetwork/server/session"
+)
+
+// Status-code regressions for POST /auth/network-create.
+//
+// The status is what every SDK, proxy and retry loop acts on. A rate limit
+// reported as 503 tells a well-behaved client "the server is broken, retry",
+// and each retry records another attempt (model/auth_model_attempt.go:52-58),
+// so the retry makes the condition worse. A validation refusal reported as 500
+// tells the user their form mistake crashed the server.
+
+// the request's own address; not loopback, so ResolveClientAddress uses it
+// verbatim and the handler buckets on exactly this client
+const (
+	statusTestClientAddress = "203.0.113.9:41001"
+	// same /29 as statusTestClientAddress, so a session built here shares the
+	// bucket the handler will compute
+	statusTestSameBucketAddress = "203.0.113.14:41002"
+	statusTestOtherAddress      = "198.51.100.20:41003"
+)
+
+func networkCreateRequest(t testing.TB, remoteAddr string, args model.NetworkCreateArgs) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal network create args: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/auth/network-create", strings.NewReader(string(body)))
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// TestNetworkCreateEmitsOneStatusForOneRateLimit.
+//
+// WHAT THIS USED TO PIN. One endpoint answered the same class of event -- "you
+// are rate limited on account creation" -- with 429 on the seedphrase branch
+// and 503 on the email/SSO/wallet branch. This test asserted that divergence.
+//
+// WHY THAT WAS WRONG. A client cannot tell "you are limited" from "the server
+// is down", and the 503 branch was the one with the tighter budget (5 per 5
+// minutes, not 5 per 24h). A 5xx instructs every well-behaved SDK to retry;
+// each retry records another attempt, so the status spent the remaining budget
+// faster and the refusal reinforced itself. Both branches now answer 429, and
+// both carry Retry-After so a client waits instead of guessing.
+func TestNetworkCreateEmitsOneStatusForOneRateLimit(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		// --- seedphrase branch: exhausted CheckNetworkCreateRateLimit ---
+		seedphraseSession := session.NewLocalClientSession(ctx, statusTestSameBucketAddress, nil)
+		defer seedphraseSession.Cancel()
+		for i := 0; i < model.NetworkCreateDailyLimit; i += 1 {
+			if err := model.CheckNetworkCreateRateLimit(ctx, seedphraseSession); err != nil {
+				t.Fatalf("priming create attempt %d was refused: %v", i+1, err)
+			}
+		}
+
+		w := httptest.NewRecorder()
+		NetworkCreate(w, networkCreateRequest(t, statusTestClientAddress, model.NetworkCreateArgs{
+			Terms: true,
+		}))
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf(
+				"seedphrase signup over the daily limit returned HTTP %d (%q), want 429",
+				w.Code, strings.TrimSpace(w.Body.String()),
+			)
+		}
+		assertRateLimitBody(t, w, "seedphrase")
+
+		// --- email/SSO/wallet branch: exhausted UserAuthAttempt ---
+		ssoSession := session.NewLocalClientSession(ctx, statusTestOtherAddress, nil)
+		defer ssoSession.Cancel()
+		for i := 0; i < model.AttemptFailedCountThreshold; i += 1 {
+			model.UserAuthAttempt(nil, ssoSession)
+		}
+
+		authJwt := "sso-token-for-a-first-time-user"
+		authJwtType := "google"
+		w = httptest.NewRecorder()
+		NetworkCreate(w, networkCreateRequest(t, statusTestOtherAddress, model.NetworkCreateArgs{
+			AuthJwt:     &authJwt,
+			AuthJwtType: &authJwtType,
+			NetworkName: "newcomernet",
+			Terms:       true,
+		}))
+		if w.Code == http.StatusServiceUnavailable {
+			t.Fatalf(
+				"the auth-attempt limit still answers 503 (%q). Every SDK reads that as "+
+					"'the server is broken, retry', and each retry records another attempt",
+				strings.TrimSpace(w.Body.String()),
+			)
+		}
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf(
+				"rate-limited SSO signup returned HTTP %d (%q), want 429 -- the same status "+
+					"the seedphrase branch gives for the same class of event",
+				w.Code, strings.TrimSpace(w.Body.String()),
+			)
+		}
+		if strings.Contains(w.Body.String(), "User auth attempts exceeded limits") {
+			t.Fatalf("429 body still carries the old opaque message: %q", strings.TrimSpace(w.Body.String()))
+		}
+		assertRateLimitBody(t, w, "sso")
+	})
+}
+
+// assertRateLimitBody checks the two properties item 4 is about: the refusal
+// says the limit is scoped to the network address rather than accusing the
+// caller, and it carries a Retry-After so a client waits a known interval
+// instead of retrying immediately into the same limit.
+func assertRateLimitBody(t testing.TB, w *httptest.ResponseRecorder, branch string) {
+	t.Helper()
+	body := strings.TrimSpace(w.Body.String())
+
+	if strings.Contains(body, "You have reached the maximum number of account creations") {
+		t.Fatalf(
+			"the %s refusal still tells the user they created the accounts: %q. The "+
+				"budget is address-scoped, so the usual recipient created none of them",
+			branch, body,
+		)
+	}
+	if !strings.Contains(body, "address") {
+		t.Fatalf(
+			"the %s refusal body %q never says the limit is scoped to the network "+
+				"address; support cannot tell a wrongly-refused user from abuse",
+			branch, body,
+		)
+	}
+
+	retryAfter := w.Header().Get("Retry-After")
+	if retryAfter == "" {
+		t.Fatalf(
+			"the %s 429 carries no Retry-After; the client can only guess when to try "+
+				"again, and guessing early costs it more of the same budget",
+			branch,
+		)
+	}
+	seconds, err := strconv.Atoi(retryAfter)
+	if err != nil || seconds <= 0 {
+		t.Fatalf("the %s 429 sent Retry-After: %q, want a positive number of seconds", branch, retryAfter)
+	}
+}
+
+// TestNetworkCreateValidationRefusalIsNotReportedAsSuccess covers the
+// error-return convention (task item 5).
+//
+// The model returns validation refusals in the body as
+// NetworkCreateResult.Error with a nil Go error. controller.NetworkCreate
+// (:21-24) converts that body error into a Go error, and RaiseHttpError
+// (router/handler_utils.go:391-405) has no numeric prefix to peel, so the
+// status is 500.
+//
+// Two properties are pinned here. The first is a genuine safety property: a
+// refusal must never reach the client as 200 with an error buried in the body,
+// which a status-checking client would read as a created account. The second is
+// the current convention -- 500 with a text/plain body -- which is itself
+// wrong for a form mistake and means NetworkCreateResult.Error is unreachable
+// over HTTP. It is pinned so it cannot drift silently.
+func TestNetworkCreateValidationRefusalIsNotReportedAsSuccess(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		w := httptest.NewRecorder()
+		NetworkCreate(w, networkCreateRequest(t, statusTestClientAddress, model.NetworkCreateArgs{
+			Terms: false,
+		}))
+
+		if w.Code == http.StatusOK {
+			t.Fatalf(
+				"a signup refused for %q returned HTTP 200 with body %q: a status-checking "+
+					"client reads that as a created account",
+				model.AgreeToTerms, strings.TrimSpace(w.Body.String()),
+			)
+		}
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf(
+				"terms-not-accepted signup returned HTTP %d (%q); the currently-pinned "+
+					"convention is 500 -- if this is now 400 that is the fix, update this test",
+				w.Code, strings.TrimSpace(w.Body.String()),
+			)
+		}
+		if strings.TrimSpace(w.Body.String()) != string(model.AgreeToTerms) {
+			t.Fatalf("refusal body was %q, want the plain message %q",
+				strings.TrimSpace(w.Body.String()), model.AgreeToTerms)
+		}
+
+		// the body is the bare message, not the NetworkCreateResult a client
+		// parses; sdk NetworkCreateResult.Error is therefore never populated
+		var result model.NetworkCreateResult
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err == nil && result.Error != nil {
+			t.Fatalf(
+				"the refusal now arrives as a parseable NetworkCreateResult with Error=%q; "+
+					"that is the fix -- update this test",
+				result.Error.Message,
+			)
+		}
+	})
+}

--- a/controller/verify_controller_test.go
+++ b/controller/verify_controller_test.go
@@ -176,12 +176,52 @@ func TestVerifySourceIpPrecedence(t *testing.T) {
 		t.Fatalf("X-Forwarded-For+port expected, got %q", got)
 	}
 
-	// 3. A trusted proxy sending a partial identity is rejected, never silently
-	// re-attributed to the proxy itself.
+	// 3. A trusted proxy sending X-Forwarded-For WITHOUT the source port is the
+	// ordinary case, not an error: stock nginx
+	// (proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for), ALB,
+	// CloudFront and Cloudflare all send a bare ip and no port header. It must
+	// resolve to the CLIENT.
+	//
+	// This case used to assert the opposite -- that a bare X-Forwarded-For is
+	// rejected -- on the reasoning that rejecting is safer than silently
+	// re-attributing the request to the proxy. The premise was right and the
+	// conclusion was wrong: the rejection is an ERROR, and router.wrap /
+	// router.wrapWithInput turn a session construction failure into HTTP 500 on
+	// every endpoint, so "reject" meant the api was down for any deployment
+	// that enumerated a normal proxy. Attribution is preserved by reading the
+	// client out of the header, which is what this now checks. The port is
+	// genuinely unknown, and 0 is how that is spelled; every /verify hash keys
+	// on the ip alone (model.ParseVerifyEgressIp, server.ClientIpHash).
 	req = newReq()
 	req.Header.Set("X-Forwarded-For", "198.51.100.2")
-	if _, err := addr(req); err == nil {
-		t.Fatal("partial forwarded source must be rejected")
+	if got := mustAddr(req); got != "198.51.100.2:0" {
+		t.Fatalf("bare X-Forwarded-For from a trusted proxy resolved as %q, want 198.51.100.2:0", got)
+	}
+
+	// 3b. The safety half the old assertion was protecting is unchanged: a
+	// header the service genuinely cannot read is never re-attributed to
+	// anything the caller chose. It falls back to the immediate peer -- the
+	// most restrictive answer available -- and the running service emits an
+	// operator report naming that peer (pinned in
+	// session.TestUnreadableForwardingHeaderFromATrustedPeerDegradesAndIsReported,
+	// which can reach the log seam from inside that package).
+	req = newReq()
+	req.Header.Set("X-Forwarded-For", "not-an-address")
+	if got := mustAddr(req); got != "10.9.9.9:5555" {
+		t.Fatalf("an unreadable forwarding header resolved as %q, want the peer 10.9.9.9:5555", got)
+	}
+
+	// 3c. And a chain is read as a chain: the entry the trusted hop appended,
+	// never the entry the client prepended.
+	req = newReq()
+	req.Header.Set("X-Forwarded-For", "6.6.6.6, 198.51.100.2")
+	if got := mustAddr(req); got != "198.51.100.2:0" {
+		t.Fatalf(
+			"a client behind the trusted proxy prepended X-Forwarded-For: 6.6.6.6 and "+
+				"/verify attributed the request to %q; it just chose its own egress "+
+				"identity",
+			got,
+		)
 	}
 
 	// 4. no forwarding headers → RemoteAddr

--- a/controller/verify_controller_test.go
+++ b/controller/verify_controller_test.go
@@ -159,13 +159,43 @@ func TestVerifySourceIpPrecedence(t *testing.T) {
 		return address
 	}
 
-	// 1. X-UR-Forwarded-For wins over everything
+	// 1. X-UR-Forwarded-For's ip:port wins over the bare form and its port
+	// companion, when the two headers name the SAME client. That is what a
+	// proxy setting both correctly sends, and it is the precedence /verify
+	// depends on: the port comes from the header that carries one.
 	req := newReq()
+	req.Header.Set("X-UR-Forwarded-For", "203.0.113.1:1111")
+	req.Header.Set("X-Forwarded-For", "203.0.113.1")
+	req.Header.Set("X-Forwarded-Source-Port", "2222")
+	if got := mustAddr(req); got != "203.0.113.1:1111" {
+		t.Fatalf("X-UR-Forwarded-For must win over the bare form of the same client, got %q", got)
+	}
+
+	// 1b. Two forwarding headers naming two DIFFERENT clients resolve to
+	// NEITHER -- they fall back to the immediate peer.
+	//
+	// This case used to assert that X-UR-Forwarded-For simply wins here. That
+	// was the forgery this precedence exists to prevent, wearing the other
+	// header name: a proxy overwrites the header IT sets and passes the
+	// client's other headers through untouched, so on any deployment whose
+	// proxy owns X-Forwarded-For (Caddy, ALB, CloudFront, Cloudflare) the
+	// client is the one that can set X-UR-Forwarded-For. Both ownership shapes
+	// exist in this project -- the warp load balancer force-overwrites
+	// X-UR-Forwarded-For, the beta Caddy front end has to strip it by hand --
+	// so neither header can be declared the authentic one, and /verify egress
+	// identity must not be a value the caller picked. See
+	// session.TestASecondForwardingHeaderCannotChooseTheBucket.
+	req = newReq()
 	req.Header.Set("X-UR-Forwarded-For", "203.0.113.1:1111")
 	req.Header.Set("X-Forwarded-For", "198.51.100.2")
 	req.Header.Set("X-Forwarded-Source-Port", "2222")
-	if got := mustAddr(req); got != "203.0.113.1:1111" {
-		t.Fatalf("X-UR-Forwarded-For must win, got %q", got)
+	if got := mustAddr(req); got != "10.9.9.9:5555" {
+		t.Fatalf(
+			"two forwarding headers named two different clients and /verify attributed "+
+				"the request to %q; neither can be shown to be the value the trusted proxy "+
+				"vouched for, so the only safe answer is the peer 10.9.9.9:5555",
+			got,
+		)
 	}
 
 	// 2. without X-UR-Forwarded-For: X-Forwarded-For + X-Forwarded-Source-Port

--- a/model/auth_model.go
+++ b/model/auth_model.go
@@ -112,7 +112,7 @@ func AuthLogin(
 
 	userAuthAttemptId, allow := UserAuthAttempt(userAuth, session)
 	if !allow {
-		return nil, maxUserAuthAttemptsError()
+		return nil, maxUserAuthAttemptsError(userAuth)
 	}
 
 	if login.UserAuth != nil {
@@ -709,7 +709,7 @@ func AuthLoginWithPassword(
 
 	userAuthAttemptId, allow := UserAuthAttempt(userAuth, session)
 	if !allow {
-		return nil, maxUserAuthAttemptsError()
+		return nil, maxUserAuthAttemptsError(userAuth)
 	}
 
 	var userId *server.Id
@@ -841,7 +841,7 @@ func AuthVerify(
 
 	userAuthAttemptId, allow := UserAuthAttempt(userAuth, session)
 	if !allow {
-		return nil, maxUserAuthAttemptsError()
+		return nil, maxUserAuthAttemptsError(userAuth)
 	}
 
 	normalVerifyCode := strings.ToLower(strings.TrimSpace(verify.VerifyCode))
@@ -975,7 +975,7 @@ func AuthVerifyCreateCode(
 	// cannot bomb a target's email/SMS or repeatedly invalidate their pending code.
 	// Each send intentionally consumes attempt budget (not marked success).
 	if _, allow := UserAuthAttempt(userAuth, session); !allow {
-		return nil, maxUserAuthAttemptsError()
+		return nil, maxUserAuthAttemptsError(userAuth)
 	}
 
 	created := false
@@ -1075,7 +1075,7 @@ func AuthPasswordResetCreateCode(
 	// cannot bomb a target's email/SMS or repeatedly invalidate their pending code.
 	// Each send intentionally consumes attempt budget (not marked success).
 	if _, allow := UserAuthAttempt(userAuth, session); !allow {
-		return nil, maxUserAuthAttemptsError()
+		return nil, maxUserAuthAttemptsError(userAuth)
 	}
 
 	created := false
@@ -1157,7 +1157,10 @@ func AuthPasswordSet(
 ) (*AuthPasswordSetResult, error) {
 	userAuthAttemptId, allow := UserAuthAttempt(nil, session)
 	if !allow {
-		return nil, maxUserAuthAttemptsError()
+		// nil user auth: the reset code must not reveal which account it
+		// belongs to, so this attempt is recorded against the client address
+		// alone and the refusal is address-scoped.
+		return nil, maxUserAuthAttemptsError(nil)
 	}
 
 	// 4 hours

--- a/model/auth_model_attempt.go
+++ b/model/auth_model_attempt.go
@@ -5,7 +5,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"time"
 
@@ -15,8 +14,51 @@ import (
 	"github.com/urnetwork/server/session"
 )
 
-func maxUserAuthAttemptsError() error {
-	return errors.New("503 User auth attempts exceeded limits.")
+// maxUserAuthAttemptsError reports the auth-attempt limit to the client.
+//
+// 429, not the 503 this used to return. A rate limit is client-attributable:
+// the request was refused because of who sent it and how often, not because the
+// service is broken. A 5xx tells every well-behaved client and SDK to retry,
+// and every retry records another attempt (see authAttemptScript), so the
+// status itself made the condition worse and did so self-reinforcingly.
+//
+// The wording depends on which budget was spent, because the two are not the
+// same event. With no user auth -- SSO signup, wallet signup, AuthPasswordSet
+// -- userAuthAttemptRedisKeys builds a key with no identity component, so the
+// budget is shared by everyone at the client address and the refused user may
+// have done nothing at all. With a user auth the budget is that account's.
+// Support cannot tell a wrongly-refused stranger from abuse if both are handed
+// the same sentence, which is why the old single message ("User auth attempts
+// exceeded limits.") is gone.
+//
+// Retry-After is the address lookback rather than the global one. Both windows
+// feed this refusal, but the address window is the binding constraint in
+// practice (5 attempts / 5 minutes against 300 / 30 minutes), and advising the
+// longer wait would hold back a legitimate caller six times longer than needed.
+// A caller that retries on the hint and is still over budget simply gets
+// another 429 carrying a fresh hint.
+func maxUserAuthAttemptsError(userAuth *string) error {
+	retryAfterSeconds := int(AttemptLookback / time.Second)
+	if userAuth == nil {
+		return &rateLimitError{
+			message: fmt.Sprintf(
+				"429 Too many recent sign-in or account-creation attempts from your "+
+					"network address. This limit is scoped to the address you are "+
+					"connecting from and is shared with everyone else on it, so someone "+
+					"else on your network may have used it. Please try again in %d minutes.",
+				int(AttemptLookback/time.Minute),
+			),
+			retryAfterSeconds: retryAfterSeconds,
+		}
+	}
+	return &rateLimitError{
+		message: fmt.Sprintf(
+			"429 Too many recent sign-in attempts for this account from your network "+
+				"address. Please try again in %d minutes.",
+			int(AttemptLookback/time.Minute),
+		),
+		retryAfterSeconds: retryAfterSeconds,
+	}
 }
 
 const AttemptLookback = 5 * time.Minute

--- a/model/network_create_rate_limit.go
+++ b/model/network_create_rate_limit.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/urnetwork/server"
@@ -12,8 +11,27 @@ import (
 const NetworkCreateDailyLimit = 5
 const NetworkCreateDailyWindow = 24 * time.Hour
 
-func maxNetworkCreateAttemptsError() error {
-	return fmt.Errorf("429 You have reached the maximum number of account creations for today. Please try again later.")
+// maxNetworkCreateAttemptsError reports the account-creation limit.
+//
+// The message used to read "You have reached the maximum number of account
+// creations for today", which is false for almost everyone who sees it: the
+// budget is keyed on the caller's network address (bucketed by subnet, see
+// server.ClientIpHashForAddr), not on the person, so the usual recipient has
+// created no accounts at all and is being refused for what others sharing the
+// address did. Saying so plainly is what lets support tell a wrongly-refused
+// user on a shared connection apart from actual abuse, instead of both being
+// handed the same accusation.
+//
+// retryAfterSeconds is the real remaining time on the window: the oldest
+// attempt still counted expires then, freeing exactly one slot.
+func maxNetworkCreateAttemptsError(retryAfterSeconds int) error {
+	return &rateLimitError{
+		message: "429 Too many accounts have been created recently from your network " +
+			"address. This limit is scoped to the address you are connecting from " +
+			"and is shared with everyone else on it, so this may not be your own " +
+			"activity. Please try again later or from a different connection.",
+		retryAfterSeconds: retryAfterSeconds,
+	}
 }
 
 // CheckNetworkCreateRateLimit checks if the IP has exceeded the daily account
@@ -30,13 +48,25 @@ func CheckNetworkCreateRateLimit(
 	}
 
 	var count int
+	// seconds until the oldest attempt still inside the window expires, which
+	// is when one slot frees up. Computed in the same statement, against the
+	// same clock, so the Retry-After we hand the client is the real wait and
+	// not a flat restatement of the window length.
+	var retryAfterSeconds int
 
 	server.Tx(ctx, func(tx server.PgTx) {
 		// Count how many network creates this IP has done in the last 24 hours
 		result, err := tx.Query(
 			ctx,
 			`
-				SELECT COUNT(*)
+				SELECT
+					COUNT(*),
+					COALESCE(
+						CEIL(EXTRACT(EPOCH FROM (
+							MIN(create_time) + INTERVAL '1 seconds' * $2 - now()
+						)))::bigint,
+						0
+					)
 				FROM network_create_attempt
 				WHERE
 					client_address_hash = $1 AND
@@ -47,7 +77,7 @@ func CheckNetworkCreateRateLimit(
 		)
 		server.WithPgResult(result, err, func() {
 			if result.Next() {
-				server.Raise(result.Scan(&count))
+				server.Raise(result.Scan(&count, &retryAfterSeconds))
 			}
 		})
 
@@ -70,7 +100,15 @@ func CheckNetworkCreateRateLimit(
 	})
 
 	if count >= NetworkCreateDailyLimit {
-		return maxNetworkCreateAttemptsError()
+		// clamp: a clock skew or a just-expired row must never produce a
+		// nonsensical hint, and the wait can never exceed the window itself
+		if retryAfterSeconds < 1 {
+			retryAfterSeconds = 1
+		}
+		if maxSeconds := int(NetworkCreateDailyWindow / time.Second); maxSeconds < retryAfterSeconds {
+			retryAfterSeconds = maxSeconds
+		}
+		return maxNetworkCreateAttemptsError(retryAfterSeconds)
 	}
 
 	return nil

--- a/model/network_create_rate_limit_regression_test.go
+++ b/model/network_create_rate_limit_regression_test.go
@@ -467,6 +467,85 @@ func TestAccountLimitRefusalIsHonestAboutItsScope(t *testing.T) {
 	})
 }
 
+// TestAccountLimitRetryHintTracksTheOldestAttempt is the assertion that tells
+// the documented Retry-After apart from a flat restatement of the window.
+//
+// CheckNetworkCreateRateLimit computes the hint in SQL, in the same statement
+// and against the same clock as the count:
+//
+//	COALESCE(CEIL(EXTRACT(EPOCH FROM (MIN(create_time) + INTERVAL '1 seconds' * $2 - now())))::bigint, 0)
+//
+// and the comment above it promises "the real remaining time on the window: the
+// oldest attempt still counted expires then, freeing exactly one slot." Nothing
+// asserted the VALUE. The test above only requires 0 < seconds <= window, and
+// api/handlers only requires that the header parses and is positive, so a flat
+// `NetworkCreateDailyWindow`, or arithmetic broken by the timestamp /
+// timestamptz mix in that expression, passed the entire suite -- and a client
+// told to come back in 24 hours when a slot frees in 4 either waits a day it
+// did not have to or hammers the endpoint because the hint was obviously wrong.
+//
+// So the attempts are backdated by a known amount and the hint has to follow
+// them. The two candidate answers are 20 hours apart, which is far outside any
+// tolerance the clock needs.
+func TestAccountLimitRetryHintTracksTheOldestAttempt(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		clientAddressHash, _, err := clientA.ClientAddressHashPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// fill the budget with attempts made 20 hours ago, so ~4h of the 24h
+		// window remains on the oldest one
+		const aged = 20 * time.Hour
+		agedAt := server.NowUtc().Add(-aged)
+		server.Tx(ctx, func(tx server.PgTx) {
+			for i := 0; i < NetworkCreateDailyLimit; i += 1 {
+				server.RaisePgResult(tx.Exec(
+					ctx,
+					`
+						INSERT INTO network_create_attempt
+						(network_create_attempt_id, client_address_hash, create_time)
+						VALUES ($1, $2, $3)
+					`,
+					server.NewId(),
+					clientAddressHash[:],
+					// spread them so MIN() has something to choose
+					agedAt.Add(time.Duration(i)*time.Minute),
+				))
+			}
+		})
+
+		err = CheckNetworkCreateRateLimit(ctx, clientA)
+		if err == nil {
+			t.Fatal("the over-limit call was allowed; the backdated attempts are still inside the window")
+		}
+		var retryAfter interface{ RetryAfterSeconds() int }
+		if !errors.As(err, &retryAfter) {
+			t.Fatalf("the account-creation refusal %q carries no retry hint for Retry-After", err)
+		}
+
+		seconds := retryAfter.RetryAfterSeconds()
+		want := int((NetworkCreateDailyWindow - aged) / time.Second)
+		flat := int(NetworkCreateDailyWindow / time.Second)
+		// generous: absorbs the test's own runtime and any clock skew between
+		// this process and postgres, while staying 19 hours clear of `flat`
+		const tolerance = 15 * 60
+		if seconds < want-tolerance || want+tolerance < seconds {
+			t.Fatalf(
+				"%d attempts made %s ago produced Retry-After = %d seconds, want ~%d (the "+
+					"time left on the OLDEST attempt). %d would be a flat restatement of the "+
+					"%s window, which is what this test exists to rule out",
+				NetworkCreateDailyLimit, aged, seconds, want, flat, NetworkCreateDailyWindow,
+			)
+		}
+	})
+}
+
 // TestAbandonedSsoSignupsDoNotSpendTheAddressWideAuthBudget pins the sharpest
 // wrongful 503 in the report, from the other side.
 //

--- a/model/network_create_rate_limit_regression_test.go
+++ b/model/network_create_rate_limit_regression_test.go
@@ -1,0 +1,638 @@
+package model
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/urnetwork/server"
+	"github.com/urnetwork/server/session"
+)
+
+// Regression suite for the wrongful 429 / 503 refusals users hit on account
+// creation. Each test is named for the user-visible outcome it prevents.
+//
+// POST /auth/network-create runs two different limiters:
+//
+//   - the seedphrase branch calls CheckNetworkCreateRateLimit
+//     (model/network_create_rate_limit.go), 5 per client-address bucket per
+//     rolling 24h, refused with "429 You have reached the maximum number of
+//     account creations for today."
+//   - the email / SSO / wallet branch calls UserAuthAttempt
+//     (model/auth_model_attempt.go), 5 per bucket per rolling 5 minutes,
+//     refused with "503 User auth attempts exceeded limits."
+//
+// Both bucket on server.ClientIpHash of the session's ClientAddress.
+
+// two addresses in different /29 networks, so they are genuinely different
+// buckets and not just different addresses inside one bucket
+const (
+	regressionClientA = "203.0.113.9:41001"
+	regressionClientB = "198.51.100.20:41002"
+	// same /29 as regressionClientA (203.0.113.8/29 spans .8-.15)
+	regressionClientANeighbour = "203.0.113.14:41003"
+	// first address of the next /29
+	regressionClientANextSubnet = "203.0.113.16:41004"
+)
+
+func regressionSession(ctx context.Context, address string) *session.ClientSession {
+	return session.NewLocalClientSession(ctx, address, nil)
+}
+
+// seedphraseCreate performs the no-auth-method signup: the branch guarded by
+// CheckNetworkCreateRateLimit.
+func seedphraseCreate(clientSession *session.ClientSession) (*NetworkCreateResult, error) {
+	return NetworkCreate(NetworkCreateArgs{Terms: true}, clientSession)
+}
+
+func networkCreateAttemptRowCount(t testing.TB, ctx context.Context) int {
+	t.Helper()
+	count := 0
+	server.Db(ctx, func(conn server.PgConn) {
+		result, err := conn.Query(ctx, `SELECT COUNT(*) FROM network_create_attempt`)
+		server.WithPgResult(result, err, func() {
+			if !result.Next() {
+				t.Fatal("network_create_attempt count returned no row")
+			}
+			server.Raise(result.Scan(&count))
+		})
+	})
+	return count
+}
+
+func mustSeedphraseCreate(t testing.TB, clientSession *session.ClientSession, what string) {
+	t.Helper()
+	result, err := seedphraseCreate(clientSession)
+	if err != nil {
+		t.Fatalf("%s was refused: %v", what, err)
+	}
+	if result.Error != nil {
+		t.Fatalf("%s failed: %s", what, result.Error.Message)
+	}
+	if result.Network == nil {
+		t.Fatalf("%s returned no network and no error", what)
+	}
+}
+
+// TestNetworkCreateBudgetIsNotSharedAcrossClientAddresses is the highest-value
+// test in this file. If the address the limiter buckets on is anything other
+// than the individual client -- the ingress proxy's own address, a constant, a
+// too-coarse mask -- then a user signing up from their own connection is
+// refused because five unrelated strangers signed up first, and the deployment
+// accepts five account creations per 24h in total.
+func TestNetworkCreateBudgetIsNotSharedAcrossClientAddresses(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+		clientB := regressionSession(ctx, regressionClientB)
+		defer clientB.Cancel()
+
+		for i := 0; i < NetworkCreateDailyLimit; i += 1 {
+			mustSeedphraseCreate(t, clientA, fmt.Sprintf("signup %d of %d from client A", i+1, NetworkCreateDailyLimit))
+		}
+
+		// client A has spent its own budget; that part is intended
+		if _, err := seedphraseCreate(clientA); err == nil {
+			t.Fatalf(
+				"client A was allowed signup %d after using its documented %d; the limiter is not being enforced at all",
+				NetworkCreateDailyLimit+1,
+				NetworkCreateDailyLimit,
+			)
+		}
+
+		// the unrelated client must be completely unaffected
+		result, err := seedphraseCreate(clientB)
+		if err != nil {
+			t.Fatalf(
+				"a first-ever signup from client address %s was refused with %q after "+
+					"%d signups from the unrelated address %s: the two clients share one "+
+					"rate-limit budget, so the deployment accepts %d account creations in "+
+					"total across all users",
+				regressionClientB, err, NetworkCreateDailyLimit, regressionClientA, NetworkCreateDailyLimit,
+			)
+		}
+		if result.Network == nil {
+			t.Fatalf("client B signup returned no network: %+v", result)
+		}
+	})
+}
+
+// TestNetworkCreateAllowsTheDocumentedNumberOfSignups pins the limit at the
+// documented number. An off-by-one that refuses the 5th signup would present to
+// that user as a wrongful 429 while every constant and comment in the file
+// still says 5.
+func TestNetworkCreateAllowsTheDocumentedNumberOfSignups(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		for i := 0; i < NetworkCreateDailyLimit; i += 1 {
+			result, err := seedphraseCreate(clientA)
+			if err != nil {
+				t.Fatalf(
+					"signup %d of the documented %d was refused with %q; the limit is "+
+						"being enforced one lower than it is documented",
+					i+1, NetworkCreateDailyLimit, err,
+				)
+			}
+			if result.Network == nil {
+				t.Fatalf("signup %d returned no network: %+v", i+1, result)
+			}
+		}
+
+		_, err := seedphraseCreate(clientA)
+		if err == nil {
+			t.Fatalf("signup %d was allowed; the documented limit of %d is not enforced",
+				NetworkCreateDailyLimit+1, NetworkCreateDailyLimit)
+		}
+		if !strings.HasPrefix(err.Error(), "429 ") {
+			t.Fatalf(
+				"over-limit signup returned %q; a client-attributable refusal must carry "+
+					"the 429 prefix that router.RaiseHttpError turns into HTTP 429",
+				err,
+			)
+		}
+
+		// A refused attempt must not itself be recorded. If it were, a client
+		// retrying on the refusal would keep its own window permanently full and
+		// could never recover, which is exactly the trap the Redis auth limiter
+		// has.
+		if count := networkCreateAttemptRowCount(t, ctx); count != NetworkCreateDailyLimit {
+			t.Fatalf(
+				"network_create_attempt holds %d rows after %d signups and 1 refusal, want %d: "+
+					"a refused attempt extended the user's own 24h window",
+				count, NetworkCreateDailyLimit, NetworkCreateDailyLimit,
+			)
+		}
+	})
+}
+
+// TestNetworkCreateBucketsWholeIpv4SubnetsTogether pins the /29 (v4) bucketing
+// in server.ClientIpHashForAddr.
+//
+// This is CURRENT, WRONGFUL behaviour deliberately pinned rather than asserted
+// away: eight consecutive IPv4 addresses share one 5-per-24h budget, so the
+// sixth person behind a carrier NAT, office, dorm or VPN egress to install the
+// app in a day gets a 429 on their first ever request. Nothing they can do
+// distinguishes them from the other occupants of the bucket. When the bucketing
+// is narrowed, this test fails and should be rewritten to assert the neighbour
+// succeeds.
+func TestNetworkCreateBucketsWholeIpv4SubnetsTogether(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+		neighbour := regressionSession(ctx, regressionClientANeighbour)
+		defer neighbour.Cancel()
+		nextSubnet := regressionSession(ctx, regressionClientANextSubnet)
+		defer nextSubnet.Cancel()
+
+		for i := 0; i < NetworkCreateDailyLimit; i += 1 {
+			mustSeedphraseCreate(t, clientA, fmt.Sprintf("signup %d from %s", i+1, regressionClientA))
+		}
+
+		if _, err := seedphraseCreate(neighbour); err == nil {
+			t.Fatalf(
+				"%s was allowed to sign up after %s used the budget; the /29 bucketing in "+
+					"server.ClientIpHashForAddr has changed -- update the note on this test",
+				regressionClientANeighbour, regressionClientA,
+			)
+		} else if !strings.HasPrefix(err.Error(), "429 ") {
+			t.Fatalf("neighbour refusal was %q, want a 429-prefixed message", err)
+		}
+
+		// the next /29 up is a different bucket
+		mustSeedphraseCreate(t, nextSubnet, "signup from the next /29")
+	})
+}
+
+// TestSeedphraseSignupRefusedForTermsDoesNotConsumeBudget: a user who submits
+// the signup form without ticking the terms box has created nothing. That
+// refusal must not spend one of their five daily slots -- otherwise five
+// mistakes lock the address out for 24 hours with zero accounts created, and
+// the client cannot tell the two refusals apart.
+func TestSeedphraseSignupRefusedForTermsDoesNotConsumeBudget(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		const termsMistakes = 3
+		for i := 0; i < termsMistakes; i += 1 {
+			result, err := NetworkCreate(NetworkCreateArgs{Terms: false}, clientA)
+			if err != nil {
+				t.Fatalf("terms-not-accepted signup %d returned a transport error: %v", i+1, err)
+			}
+			if result.Error == nil || result.Error.Message != AgreeToTerms {
+				t.Fatalf("terms-not-accepted signup %d returned %+v, want the AgreeToTerms body error", i+1, result)
+			}
+		}
+
+		if count := networkCreateAttemptRowCount(t, ctx); count != 0 {
+			t.Fatalf(
+				"%d rate-limit attempts were recorded for %d signups that were refused "+
+					"before anything was created: an ordinary form mistake now spends the "+
+					"user's daily account-creation budget",
+				count, termsMistakes,
+			)
+		}
+
+		// and the user still has their full documented budget
+		for i := 0; i < NetworkCreateDailyLimit; i += 1 {
+			mustSeedphraseCreate(t, clientA, fmt.Sprintf("signup %d after %d terms mistakes", i+1, termsMistakes))
+		}
+	})
+}
+
+// TestEmailSignupValidationMistakesDoNotConsumeTheAuthBudget.
+//
+// WHAT THIS USED TO PIN. model.NetworkCreate consumed UserAuthAttempt at
+// network_model.go:217, BEFORE the terms check (:222) and before network-name
+// validation (:231). Every ordinary form mistake therefore spent one of five
+// slots in a 5-minute window, and the email branch never calls
+// SetUserAuthAttemptSuccess to drain it. Four mistakes and the user's next --
+// correct -- submission was refused with "503 User auth attempts exceeded
+// limits.": a server-fault status that tells every retrying client to try
+// again, and each retry records another attempt. This test asserted exactly
+// that, on the grounds that the bug should be visible until it was fixed.
+//
+// WHY THAT WAS WRONG. A user's form mistake is not an authentication attempt.
+// Charging it spent a budget that, for a signup carrying no user auth, is
+// shared with every other client on the same address -- so one person fumbling
+// a form refused strangers.
+//
+// The limiter now runs after input validation (model/network_model.go), so the
+// assertion is inverted: the corrected submission must go through.
+func TestEmailSignupValidationMistakesDoNotConsumeTheAuthBudget(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		userAuth := "regression-burned@example.com"
+		password := "SomeValidPassword123!"
+
+		// more mistakes than the whole 5-minute budget, to show none are charged
+		mistakes := AttemptFailedCountThreshold + 2
+		for i := 0; i < mistakes; i += 1 {
+			result, err := NetworkCreate(NetworkCreateArgs{
+				UserAuth: &userAuth,
+				Password: &password,
+				Terms:    false,
+			}, clientA)
+			if err != nil {
+				t.Fatalf(
+					"terms mistake %d was refused with %q instead of returning the "+
+						"AgreeToTerms body error: an unticked terms box is spending the "+
+						"auth-attempt budget again",
+					i+1, err,
+				)
+			}
+			if result.Error == nil || result.Error.Message != AgreeToTerms {
+				t.Fatalf("terms mistake %d returned %+v, want the AgreeToTerms body error", i+1, result)
+			}
+		}
+
+		// a network name that is already taken is the same class of mistake
+		result, err := NetworkCreate(NetworkCreateArgs{
+			UserAuth:    &userAuth,
+			Password:    &password,
+			NetworkName: "a",
+			Terms:       true,
+		}, clientA)
+		if err != nil {
+			t.Fatalf("an invalid network name was refused with %q, want a body error", err)
+		}
+		if result.Error == nil {
+			t.Fatalf("an invalid network name returned %+v, want a body error", result)
+		}
+
+		result, err = NetworkCreate(NetworkCreateArgs{
+			UserAuth:    &userAuth,
+			Password:    &password,
+			NetworkName: "regressionnet",
+			Terms:       true,
+		}, clientA)
+		if err != nil {
+			t.Fatalf(
+				"the corrected signup after %d form mistakes was refused with %q: "+
+					"pre-validation refusals are charging the auth-attempt limiter again, "+
+					"so a user's own typing locks them out",
+				mistakes, err,
+			)
+		}
+		if result.Error != nil {
+			t.Fatalf("the corrected signup returned the body error %q", result.Error.Message)
+		}
+		if result.VerificationRequired == nil {
+			t.Fatalf("the corrected signup returned %+v, want a verification-required result", result)
+		}
+	})
+}
+
+// TestAuthAttemptLimitIsReportedAsAClientError.
+//
+// WHAT THIS REPLACES. maxUserAuthAttemptsError used to return
+// "503 User auth attempts exceeded limits." A 5xx tells every well-behaved
+// client and SDK that the server is broken and the request should be retried;
+// every retry records another attempt (model/auth_model_attempt.go
+// authAttemptScript), so the status itself consumed the remaining budget faster
+// and the condition reinforced itself. Rate limiting is client-attributable.
+//
+// The message is also checked here. "User auth attempts exceeded limits" told a
+// user nothing about why they, personally, were refused -- and for a signup
+// with no user auth the budget is not theirs at all, it is the whole address's.
+func TestAuthAttemptLimitIsReportedAsAClientError(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		for i := 0; i < AttemptFailedCountThreshold; i += 1 {
+			UserAuthAttempt(nil, clientA)
+		}
+
+		authJwt := "sso-token-for-a-first-time-user"
+		authJwtType := "google"
+		_, err := NetworkCreate(NetworkCreateArgs{
+			AuthJwt:     &authJwt,
+			AuthJwtType: &authJwtType,
+			NetworkName: "overbudgetnet",
+			Terms:       true,
+		}, clientA)
+		if err == nil {
+			t.Fatal("an over-budget signup was allowed; the auth-attempt limiter is not enforced")
+		}
+		if strings.HasPrefix(err.Error(), "503 ") {
+			t.Fatalf(
+				"the auth-attempt limit still answers %q. A 5xx tells every SDK to retry, "+
+					"and each retry records another attempt, so the status makes the "+
+					"refusal self-reinforcing",
+				err,
+			)
+		}
+		if !strings.HasPrefix(err.Error(), "429 ") {
+			t.Fatalf(
+				"the auth-attempt limit answers %q; a client-attributable refusal must "+
+					"carry the 429 prefix router.RaiseHttpError turns into the status",
+				err,
+			)
+		}
+		if strings.Contains(err.Error(), "User auth attempts exceeded limits") {
+			t.Fatalf("the refusal still uses the old opaque message: %q", err)
+		}
+		if !strings.Contains(err.Error(), "address") {
+			t.Fatalf(
+				"an identity-less auth-attempt refusal reads %q. That budget is shared by "+
+					"everyone at the client address, so the message has to say the limit is "+
+					"address-scoped -- otherwise support cannot tell a wrongly-refused "+
+					"stranger from abuse",
+				err,
+			)
+		}
+
+		// and it carries a machine-readable wait
+		var retryAfter interface{ RetryAfterSeconds() int }
+		if !errors.As(err, &retryAfter) {
+			t.Fatalf("the auth-attempt refusal %q carries no retry hint for Retry-After", err)
+		}
+		if seconds := retryAfter.RetryAfterSeconds(); seconds <= 0 {
+			t.Fatalf("the auth-attempt refusal reported RetryAfterSeconds()=%d", seconds)
+		}
+	})
+}
+
+// TestAccountLimitRefusalIsHonestAboutItsScope covers item 4 on the
+// account-creation limiter.
+//
+// The message used to read "You have reached the maximum number of account
+// creations for today." The recipient has, in the overwhelming majority of
+// cases, created none: the budget is keyed on a subnet of the client address
+// (server.ClientIpHashForAddr), so a user on a shared connection is refused for
+// what other people did and then told it was their own doing.
+func TestAccountLimitRefusalIsHonestAboutItsScope(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		for i := 0; i < NetworkCreateDailyLimit; i += 1 {
+			mustSeedphraseCreate(t, clientA, fmt.Sprintf("signup %d", i+1))
+		}
+
+		_, err := seedphraseCreate(clientA)
+		if err == nil {
+			t.Fatal("the over-limit signup was allowed")
+		}
+		if strings.Contains(err.Error(), "You have reached the maximum number of account creations") {
+			t.Fatalf(
+				"the refusal still accuses the caller of creating the accounts: %q. The "+
+					"budget is address-scoped, so the usual recipient created none of them",
+				err,
+			)
+		}
+		if !strings.Contains(err.Error(), "address") {
+			t.Fatalf(
+				"the account-creation refusal reads %q and never says the limit is scoped "+
+					"to the network address; support cannot tell these apart from abuse",
+				err,
+			)
+		}
+
+		var retryAfter interface{ RetryAfterSeconds() int }
+		if !errors.As(err, &retryAfter) {
+			t.Fatalf("the account-creation refusal %q carries no retry hint for Retry-After", err)
+		}
+		seconds := retryAfter.RetryAfterSeconds()
+		if seconds <= 0 || int(NetworkCreateDailyWindow/time.Second) < seconds {
+			t.Fatalf(
+				"the account-creation refusal reported RetryAfterSeconds()=%d, want a "+
+					"positive value no larger than the %s window",
+				seconds, NetworkCreateDailyWindow,
+			)
+		}
+	})
+}
+
+// TestAbandonedSsoSignupsDoNotSpendTheAddressWideAuthBudget pins the sharpest
+// wrongful 503 in the report, from the other side.
+//
+// THE MECHANISM IS UNCHANGED AND IS STILL PINNED BELOW. model/network_model.go
+// parses userAuth from networkCreate.UserAuth, and NormalUserAuthV1(nil)
+// returns nil. SSO and wallet signups send no user_auth at all, so nil is what
+// reaches UserAuthAttempt -- and userAuthAttemptRedisKeys' nil branch builds a
+// key with NO user component. Every SSO and every wallet signup from one public
+// address really does share a single bucket of 5 per 5 minutes. That bucketing
+// is deliberate anti-abuse policy and is NOT changed here; the key shape is
+// asserted so it cannot drift.
+//
+// WHAT THIS USED TO PIN. Because the limiter ran before the terms check, four
+// people on one public address who opened the signup form and did not tick the
+// box would exhaust that shared bucket, and the fifth -- a first-time user who
+// had done nothing -- was refused with "503 User auth attempts exceeded
+// limits." The old test asserted that refusal.
+//
+// WHY THAT WAS WRONG. Abandoning a form is not an authentication attempt.
+// Spending a shared budget on it turns other people's hesitation into a refusal
+// for a stranger, and the shared bucket makes it invisible to everyone
+// involved. The bucket is not widened; it is simply no longer charged for
+// submissions that were never going to create anything.
+func TestAbandonedSsoSignupsDoNotSpendTheAddressWideAuthBudget(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		// the key shape itself: no identity, so no per-user separation. This is
+		// current, intended behaviour, pinned so a change is deliberate.
+		addressHashHex := hex.EncodeToString([]byte("0123456789abcdef"))
+		addressKey, globalKey := userAuthAttemptRedisKeys(nil, addressHashHex)
+		if globalKey != "" {
+			t.Fatalf("identity-less auth attempt built a global key %q; the nil branch changed", globalKey)
+		}
+		if !strings.Contains(addressKey, addressHashHex) {
+			t.Fatalf("identity-less auth attempt key %q does not contain the address hash", addressKey)
+		}
+		if strings.Contains(addressKey, "user_") {
+			t.Fatalf(
+				"identity-less auth attempt key %q now carries a user component; the "+
+					"address-wide bucketing changed -- that is a limiter policy decision, "+
+					"update the note on this test",
+				addressKey,
+			)
+		}
+
+		clientA := regressionSession(ctx, regressionClientA)
+		defer clientA.Cancel()
+
+		// more abandoned signups than the whole shared bucket holds
+		attempts := AttemptFailedCountThreshold + 2
+		for i := 0; i < attempts; i += 1 {
+			// a distinct person each time: SSO carries no user_auth, so nothing
+			// in the request distinguishes them to the limiter
+			authJwt := fmt.Sprintf("sso-token-for-person-%d", i)
+			authJwtType := "google"
+			result, err := NetworkCreate(NetworkCreateArgs{
+				AuthJwt:     &authJwt,
+				AuthJwtType: &authJwtType,
+				Terms:       false,
+			}, clientA)
+			if err != nil {
+				t.Fatalf(
+					"abandoned sso signup %d was refused with %q instead of returning a "+
+						"body error: an unticked terms box is spending the address-wide "+
+						"bucket again",
+					i+1, err,
+				)
+			}
+			if result.Error == nil || result.Error.Message != AgreeToTerms {
+				t.Fatalf("sso signup %d returned %+v, want the AgreeToTerms body error", i+1, result)
+			}
+		}
+
+		newcomerJwt := "sso-token-for-a-first-time-user"
+		newcomerJwtType := "google"
+		_, err := NetworkCreate(NetworkCreateArgs{
+			AuthJwt:     &newcomerJwt,
+			AuthJwtType: &newcomerJwtType,
+			NetworkName: "newcomernet",
+			Terms:       true,
+		}, clientA)
+		// The SSO token above is not a real signed JWT, so this submission
+		// cannot reach a created account: ParseAuthJwt returns nil and
+		// NetworkCreate falls through to "invalid login". What matters is that
+		// it got PAST the limiter -- a rate-limit refusal is a 429 and would
+		// have been returned before the branch dispatch was ever reached.
+		if err != nil && strings.HasPrefix(err.Error(), "429 ") {
+			t.Fatalf(
+				"a first-time SSO signup from %s was rate limited with %q after %d "+
+					"unrelated people abandoned the form from the same address: abandoned "+
+					"forms are spending the shared bucket again, and this user did nothing",
+				regressionClientA, err, attempts,
+			)
+		}
+	})
+}
+
+// TestValidSignupsStillSpendTheAuthBudget is the abuse-side counterpart to the
+// test above, and the reason moving the limiter is not a weakening.
+//
+// Only pre-validation refusals stopped being charged. A submission that is
+// well-formed -- the shape an attacker actually sends -- still consumes a slot,
+// and the address-wide bucket still refuses the caller at the documented count.
+func TestValidSignupsStillSpendTheAuthBudget(t *testing.T) {
+	server.DefaultTestEnv().Run(t, func(t testing.TB) {
+		ctx := context.Background()
+
+		clientB := regressionSession(ctx, regressionClientB)
+		defer clientB.Cancel()
+
+		// These tokens are not real signed JWTs, so each submission ends at
+		// NetworkCreate's "invalid login" fallthrough -- which is BELOW the
+		// limiter, so each one is charged exactly as a genuine attempt is. That
+		// is the shape an attacker sends: well-formed input, no account.
+		//
+		// A refusal that costs nothing is interleaved before every charged
+		// submission. This is the assertion that discriminates the fix from the
+		// bug in the ABUSE direction: if the limiter moved back above input
+		// validation, those free refusals would be charged too and the count
+		// below would come out at half. Making pre-validation refusals free
+		// must not hand an attacker a way to stretch the budget.
+		authJwtType := "google"
+		rateLimitedAt := 0
+		for i := 0; i < AttemptFailedCountThreshold+1; i += 1 {
+			skipped := "sso-token-abandoned"
+			if _, err := NetworkCreate(NetworkCreateArgs{
+				AuthJwt:     &skipped,
+				AuthJwtType: &authJwtType,
+				Terms:       false,
+			}, clientB); err != nil {
+				t.Fatalf("interleaved terms refusal %d was itself rate limited: %v", i+1, err)
+			}
+
+			authJwt := fmt.Sprintf("sso-token-attacker-%d", i)
+			networkName := fmt.Sprintf("attackernet%d", i)
+			_, err := NetworkCreate(NetworkCreateArgs{
+				AuthJwt:     &authJwt,
+				AuthJwtType: &authJwtType,
+				NetworkName: networkName,
+				Terms:       true,
+			}, clientB)
+			if err != nil && strings.HasPrefix(err.Error(), "429 ") {
+				rateLimitedAt = i + 1
+				break
+			}
+		}
+		if rateLimitedAt == 0 {
+			t.Fatalf(
+				"%d well-formed submissions from one address were all admitted past the "+
+					"limiter; it no longer charges submissions that reach the create "+
+					"branches, so moving it below input validation has weakened it",
+				AttemptFailedCountThreshold+1,
+			)
+		}
+		// authAttemptScript records the attempt and then admits it only when the
+		// resulting count is strictly below the threshold, so AttemptFailedCountThreshold-1
+		// are admitted and the AttemptFailedCountThreshold'th is refused. That
+		// is pre-existing limiter behaviour, unchanged by this fix and pinned
+		// here so a change to it is deliberate.
+		if rateLimitedAt != AttemptFailedCountThreshold {
+			t.Fatalf(
+				"well-formed submissions were rate limited at %d, want %d: the limit is "+
+					"enforced at a different count than it is written",
+				rateLimitedAt, AttemptFailedCountThreshold,
+			)
+		}
+	})
+}

--- a/model/network_model.go
+++ b/model/network_model.go
@@ -224,12 +224,25 @@ func NetworkCreate(
 	// corrected submission was refused too. A form mistake must not spend a
 	// shared budget.
 	//
-	// Nothing between here and the limiter grants a capability that is not
-	// already available unauthenticated and unlimited: ValidateNetworkName is
-	// pure, and checkNetworkNameAvailability is the same read-only name lookup
-	// POST /auth/network-check (api/api.go) already serves to anyone with no
-	// limiter at all. Everything that creates or mutates state stays below the
-	// limiter.
+	// Nothing between here and the limiter WRITES. ValidateNetworkName and the
+	// user-auth normalisation are pure; checkNetworkNameAvailability is two
+	// reads. Everything that creates or mutates state -- networkCreateUserAuth,
+	// ParseAuthJwt, networkCreateAuthJwt, UseWalletAuthChallenge,
+	// networkCreateWalletAuth, the search index Add, auditNetworkCreate, JWT
+	// minting -- stays below the limiter.
+	//
+	// Be precise about what the reorder does hand out unmetered, because the
+	// obvious sentence ("it is the same lookup /auth/network-check already
+	// serves") is not quite true and this comment is load-bearing for anyone
+	// moving code across the limiter later. checkNetworkNameAvailability is a
+	// SUPERSET of NetworkCheck: both run the fuzzy networkNameSearch, and it
+	// adds an exact `SELECT network_id FROM network WHERE network_name = $1`
+	// inside a transaction. So the reorder does widen the free oracle slightly
+	// -- exact-name existence for names the fuzzy search misses -- and costs
+	// one extra unmetered read transaction per unauthenticated request. That is
+	// acceptable because POST /auth/network-check (api/api.go) is already
+	// unauthenticated, unlimited and DB-backed, so no new capability appears;
+	// it is not acceptable as licence to move anything else up here.
 
 	if !networkCreate.Terms {
 		result := &NetworkCreateResult{

--- a/model/network_model.go
+++ b/model/network_model.go
@@ -213,11 +213,23 @@ func NetworkCreate(
 		}
 	}
 
-	// email/SSO/wallet paths use the existing auth rate limit
-	userAuthAttemptId, allow := UserAuthAttempt(userAuth, session)
-	if !allow {
-		return nil, maxUserAuthAttemptsError()
-	}
+	// INPUT VALIDATION RUNS FIRST, BEFORE ANY LIMITER IS CHARGED.
+	//
+	// UserAuthAttempt used to be consumed here, above every check below. That
+	// meant an unticked terms box, a network name that was too short, or a
+	// network name someone else already has each burned one of five slots in a
+	// five-minute window -- and for a signup with no user auth (SSO, wallet)
+	// those slots are shared by everyone at the client address, so ordinary
+	// form mistakes refused strangers. Four mistakes and the user's own
+	// corrected submission was refused too. A form mistake must not spend a
+	// shared budget.
+	//
+	// Nothing between here and the limiter grants a capability that is not
+	// already available unauthenticated and unlimited: ValidateNetworkName is
+	// pure, and checkNetworkNameAvailability is the same read-only name lookup
+	// POST /auth/network-check (api/api.go) already serves to anyone with no
+	// limiter at all. Everything that creates or mutates state stays below the
+	// limiter.
 
 	if !networkCreate.Terms {
 		result := &NetworkCreateResult{
@@ -250,20 +262,30 @@ func NetworkCreate(
 		return result, nil
 	}
 
+	// an unparseable email or phone number is a form mistake like any other,
+	// so it is refused here rather than after the limiter below
+	if networkCreate.UserAuth != nil && userAuth == nil {
+		result := &NetworkCreateResult{
+			Error: &NetworkCreateResultError{
+				Message: "Invalid email or phone number.",
+			},
+		}
+		return result, nil
+	}
+
 	containsProfanity := goaway.IsProfane(validatedNetworkName)
+
+	// email/SSO/wallet paths use the existing auth rate limit. The input is
+	// valid by this point, so a slot is only ever spent on a submission that
+	// would otherwise create an account.
+	userAuthAttemptId, allow := UserAuthAttempt(userAuth, session)
+	if !allow {
+		return nil, maxUserAuthAttemptsError(userAuth)
+	}
 
 	if networkCreate.UserAuth != nil {
 		// user is creating a network via email/phone + pass
 		// validate the user does not exist
-
-		if userAuth == nil {
-			result := &NetworkCreateResult{
-				Error: &NetworkCreateResultError{
-					Message: "Invalid email or phone number.",
-				},
-			}
-			return result, nil
-		}
 
 		resultNetworkCreate := networkCreateUserAuth(
 			session.Ctx,

--- a/model/rate_limit_error.go
+++ b/model/rate_limit_error.go
@@ -1,0 +1,22 @@
+package model
+
+// rateLimitError is a refusal the client caused rather than a server fault.
+//
+// It carries the "429 " prefix router.RaiseHttpError peels into the HTTP
+// status, plus the retry hint that same function turns into a Retry-After
+// header. The header is read off this type through a one-method interface, so
+// model does not have to import the router.
+type rateLimitError struct {
+	message string
+	// seconds until the caller's budget is expected to have room. Zero means
+	// the window is not known and no Retry-After is sent.
+	retryAfterSeconds int
+}
+
+func (self *rateLimitError) Error() string {
+	return self.message
+}
+
+func (self *rateLimitError) RetryAfterSeconds() int {
+	return self.retryAfterSeconds
+}

--- a/model/wallet_auth_challenge_attempt.go
+++ b/model/wallet_auth_challenge_attempt.go
@@ -74,6 +74,30 @@ func WalletAuthChallengeAttempt(
 			return failedCount < WalletAuthChallengeAttemptFailedCountThreshold
 		}
 
+		// This threshold keys on client_address_port as well as the address
+		// hash, which has two consequences an operator should know about, and
+		// neither is repaired here.
+		//
+		// The port is CLIENT-INFLUENCED wherever a trusted proxy passes
+		// X-Forwarded-Source-Port or X-UR-Forwarded-For through instead of
+		// overwriting them, so a caller behind such a proxy can vary one header
+		// and get a fresh bucket per attempt. The remedy is the proxy's, and it
+		// is what every report in session/client_session.go now states: a
+		// trusted proxy must overwrite or strip all three forwarding headers.
+		//
+		// The port also MOVES with the deployment's proxy. Where the proxy
+		// sends a bare X-Forwarded-For and no port companion, the resolved port
+		// is 0 for every client, so this key becomes per-/29 instead of
+		// per-connection: the threshold binds for the first time (a wedged
+		// deployment's ephemeral peer port made it per-connection, i.e. never),
+		// and at the same time five failed challenges start being shared across
+		// everyone in a /29.
+		//
+		// Dropping the port from the key would close the first at the cost of
+		// making the second universal -- a shared budget for every deployment,
+		// which is the wrongful-refusal failure this branch exists to remove,
+		// in a limiter this suite does not cover. So it is left alone
+		// deliberately rather than by omission.
 		var attempts []WalletAuthChallengeAttemptResult
 		result, err := tx.Query(
 			session.Ctx,

--- a/router/handler_error_test.go
+++ b/router/handler_error_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/urnetwork/connect"
+	"github.com/urnetwork/server/session"
 )
 
 // controller errors use the "<code> message" convention, and the auth
@@ -75,55 +76,86 @@ func (self *retryAfterTestError) RetryAfterSeconds() int {
 	return self.seconds
 }
 
-// TestRaiseHttpErrorRetryAfterSurvivesImplTagging.
+// TestImplTaggingKeepsTheRetryAfterHint.
 //
-// WrapRequireAuth, WrapRequireClient and WrapNoAuth all re-wrap an impl error
-// to tag it with the impl name. They used to do that with
+// WrapRequireAuth, WrapRequireClient and WrapNoAuth all tag an impl error with
+// the impl name before it reaches RaiseHttpError. They used to do that with
 //
 //	fmt.Errorf("[%s]%s", implName(impl), err)
 //
-// which flattens the error to text. The status code still survived, because
-// httpErrorCodeRegex peels the bracketed tag out of the message -- so the
-// symptom was invisible in the status: a 429 with the Retry-After silently
-// gone. errors.As cannot traverse a %s wrap.
+// which flattens the error to text. errors.As cannot traverse a %s wrap, and
+// errors.As is how RaiseHttpError finds the Retry-After hint. The status code
+// still came out right -- httpErrorCodeRegex peels the bracketed tag out of the
+// message either way -- so the whole symptom was a 429 that silently lost its
+// retry hint, leaving the client to guess, and guessing early costs it more
+// budget.
 //
-// Every rate limit that exists today happens to be reached through
-// WrapWithInputNoAuth, which does not tag, so nothing is broken in the shipped
-// code. This test is here so the next rate limit added behind an authenticated
-// route does not lose its retry hint without anything failing.
-func TestRaiseHttpErrorRetryAfterSurvivesImplTagging(t *testing.T) {
+// The three sites are now one function, tagImplError, so this test can pin all
+// of them. It drives the real WrapNoAuth end to end as well, because a test
+// that writes its own fmt.Errorf("[impl]%w", ...) passes whatever the wrappers
+// do -- the first version of this test did exactly that and stayed green when
+// the production tagging was reverted to %s.
+//
+// Every rate limit that exists today is reached through WrapWithInputNoAuth,
+// which does not tag at all, so nothing shipped is broken. This is for the next
+// rate limit added behind a wrapper that does.
+func TestImplTaggingKeepsTheRetryAfterHint(t *testing.T) {
 	rateLimited := &retryAfterTestError{message: "429 Too many attempts.", seconds: 300}
 
-	for _, testCase := range []struct {
-		what string
-		err  error
-	}{
-		{"raised directly", rateLimited},
-		{"tagged by one wrapper", fmt.Errorf("[impl]%w", rateLimited)},
-		{"tagged by two wrappers", fmt.Errorf("[outer]%w", fmt.Errorf("[inner]%w", rateLimited))},
-	} {
-		w := httptest.NewRecorder()
-		RaiseHttpError(testCase.err, w)
-
+	assertRetryAfter := func(what string, w *httptest.ResponseRecorder) {
+		t.Helper()
 		if w.Code != 429 {
-			t.Fatalf("%s: status %d, want 429", testCase.what, w.Code)
+			t.Fatalf("%s: status %d, want 429", what, w.Code)
 		}
 		if got := w.Header().Get("Retry-After"); got != "300" {
 			t.Fatalf(
 				"%s: Retry-After=%q, want \"300\". The impl tag was applied with %%s "+
 					"instead of %%w, so errors.As can no longer reach the rate limit and "+
-					"the client is left guessing when to retry -- guessing early costs it "+
-					"more budget",
-				testCase.what, got,
+					"the client is left guessing when to retry",
+				what, got,
 			)
 		}
 		if body := strings.TrimRight(w.Body.String(), "\n"); body != "Too many attempts." {
-			t.Fatalf("%s: body %q, want the untagged message", testCase.what, body)
+			t.Fatalf("%s: body %q, want the untagged message", what, body)
 		}
 	}
 
-	// an error with no retry hint must not grow one
+	// the production tagging, through the production wrapper
 	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/", nil)
+	req.RemoteAddr = "127.0.0.1:52344"
+	WrapNoAuth(
+		func(clientSession *session.ClientSession) (string, error) {
+			return "", rateLimited
+		},
+		w,
+		req,
+	)
+	assertRetryAfter("WrapNoAuth end to end", w)
+
+	// tagImplError is the single function the other two wrappers share, so
+	// pinning it here pins WrapRequireAuth and WrapRequireClient too -- neither
+	// of which can be driven end to end without minting a JWT
+	impl := func(clientSession *session.ClientSession) (string, error) { return "", rateLimited }
+	for _, testCase := range []struct {
+		what string
+		err  error
+	}{
+		{"raised directly", rateLimited},
+		{"tagged once", tagImplError(impl, rateLimited)},
+		{"tagged twice", tagImplError(impl, tagImplError(impl, rateLimited))},
+	} {
+		w := httptest.NewRecorder()
+		RaiseHttpError(testCase.err, w)
+		assertRetryAfter(testCase.what, w)
+	}
+
+	if tagImplError(impl, nil) != nil {
+		t.Fatal("tagImplError turned a nil error into a non-nil one")
+	}
+
+	// an error with no retry hint must not grow one
+	w = httptest.NewRecorder()
 	RaiseHttpError(fmt.Errorf("[impl]403 Nope."), w)
 	if got := w.Header().Get("Retry-After"); got != "" {
 		t.Fatalf("a non-rate-limit error carried Retry-After=%q", got)

--- a/router/handler_error_test.go
+++ b/router/handler_error_test.go
@@ -57,3 +57,82 @@ func TestRaiseHttpError(t *testing.T) {
 	connect.AssertEqual(t, code, 500)
 	connect.AssertEqual(t, statusError, true)
 }
+
+// retryAfterTestError is the shape model.rateLimitError presents to the router:
+// a "429 ..." message plus a RetryAfterSeconds() int read through a one-method
+// interface. model's own type is unexported, so this stands in for it -- which
+// means this pins the RaiseHttpError seam, not the seven model call sites.
+type retryAfterTestError struct {
+	message string
+	seconds int
+}
+
+func (self *retryAfterTestError) Error() string {
+	return self.message
+}
+
+func (self *retryAfterTestError) RetryAfterSeconds() int {
+	return self.seconds
+}
+
+// TestRaiseHttpErrorRetryAfterSurvivesImplTagging.
+//
+// WrapRequireAuth, WrapRequireClient and WrapNoAuth all re-wrap an impl error
+// to tag it with the impl name. They used to do that with
+//
+//	fmt.Errorf("[%s]%s", implName(impl), err)
+//
+// which flattens the error to text. The status code still survived, because
+// httpErrorCodeRegex peels the bracketed tag out of the message -- so the
+// symptom was invisible in the status: a 429 with the Retry-After silently
+// gone. errors.As cannot traverse a %s wrap.
+//
+// Every rate limit that exists today happens to be reached through
+// WrapWithInputNoAuth, which does not tag, so nothing is broken in the shipped
+// code. This test is here so the next rate limit added behind an authenticated
+// route does not lose its retry hint without anything failing.
+func TestRaiseHttpErrorRetryAfterSurvivesImplTagging(t *testing.T) {
+	rateLimited := &retryAfterTestError{message: "429 Too many attempts.", seconds: 300}
+
+	for _, testCase := range []struct {
+		what string
+		err  error
+	}{
+		{"raised directly", rateLimited},
+		{"tagged by one wrapper", fmt.Errorf("[impl]%w", rateLimited)},
+		{"tagged by two wrappers", fmt.Errorf("[outer]%w", fmt.Errorf("[inner]%w", rateLimited))},
+	} {
+		w := httptest.NewRecorder()
+		RaiseHttpError(testCase.err, w)
+
+		if w.Code != 429 {
+			t.Fatalf("%s: status %d, want 429", testCase.what, w.Code)
+		}
+		if got := w.Header().Get("Retry-After"); got != "300" {
+			t.Fatalf(
+				"%s: Retry-After=%q, want \"300\". The impl tag was applied with %%s "+
+					"instead of %%w, so errors.As can no longer reach the rate limit and "+
+					"the client is left guessing when to retry -- guessing early costs it "+
+					"more budget",
+				testCase.what, got,
+			)
+		}
+		if body := strings.TrimRight(w.Body.String(), "\n"); body != "Too many attempts." {
+			t.Fatalf("%s: body %q, want the untagged message", testCase.what, body)
+		}
+	}
+
+	// an error with no retry hint must not grow one
+	w := httptest.NewRecorder()
+	RaiseHttpError(fmt.Errorf("[impl]403 Nope."), w)
+	if got := w.Header().Get("Retry-After"); got != "" {
+		t.Fatalf("a non-rate-limit error carried Retry-After=%q", got)
+	}
+
+	// a zero hint means "window unknown" and must not be sent as Retry-After: 0
+	w = httptest.NewRecorder()
+	RaiseHttpError(&retryAfterTestError{message: "429 Too many attempts.", seconds: 0}, w)
+	if got := w.Header().Get("Retry-After"); got != "" {
+		t.Fatalf("a zero retry hint was sent as Retry-After=%q", got)
+	}
+}

--- a/router/handler_forwarded_address_test.go
+++ b/router/handler_forwarded_address_test.go
@@ -233,6 +233,28 @@ func TestSecondForwardingHeaderDoesNotReachTheHandler(t *testing.T) {
 				"X-Forwarded-For":    "6.6.6.6",
 			},
 		},
+		// The two below are the shapes the first pass of the conflict rule
+		// let through, at the boundary where it matters. The proxy's header
+		// is present and names only an address inside an enumerated CIDR
+		// (here 127.0.0.0/8, the shipped default), so it makes no claim about
+		// a client -- and a header that makes no claim used to be unable to
+		// contradict the client's, which handed the client the address it
+		// wrote. This is the shape a client reaches on the beta deploy if
+		// X-UR-Forwarded-For is ever passed through.
+		{
+			"proxy's X-Forwarded-For names only an enumerated hop, client adds X-UR-Forwarded-For",
+			map[string]string{
+				"X-Forwarded-For":    "127.0.0.9",
+				"X-UR-Forwarded-For": "6.6.6.6:1234",
+			},
+		},
+		{
+			"proxy's X-UR-Forwarded-For names only an enumerated hop, client adds X-Forwarded-For",
+			map[string]string{
+				"X-UR-Forwarded-For": "127.0.0.9:5000",
+				"X-Forwarded-For":    "6.6.6.6",
+			},
+		},
 	} {
 		for _, run := range []struct {
 			wrapper string

--- a/router/handler_forwarded_address_test.go
+++ b/router/handler_forwarded_address_test.go
@@ -1,0 +1,226 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/urnetwork/server/session"
+)
+
+// Regression suite for the HTTP 500 an operator could be talked into.
+//
+// session.ResolveClientAddress used to require, from a trusted peer, either
+// X-UR-Forwarded-For as ip:port or X-Forwarded-For paired with
+// X-Forwarded-Source-Port and single-hop. Anything else was an ERROR, and both
+// wrap and wrapWithInput answer a session construction failure with
+//
+//	http.Error(w, err.Error(), http.StatusInternalServerError)
+//
+// -- for every endpoint on the api, not just signup.
+//
+// Meanwhile session's misconfiguration report tells an operator whose ingress
+// proxy is not enumerated to add its subnet to BRINGYOUR_TRUSTED_PROXY_CIDRS.
+// Stock nginx (proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for),
+// ALB, CloudFront and Cloudflare all send a bare X-Forwarded-For and no source
+// port, and $proxy_add_x_forwarded_for APPENDS, so a second hop adds the comma
+// that was also rejected. Following the report therefore turned a degraded
+// deployment (one shared rate-limit budget) into a dead one (500 on every
+// request).
+//
+// These tests assert at the HTTP boundary, because that is where the defect
+// was: a unit test on ResolveClientAddress checks the input to the thing that
+// produced the 500, not the 500.
+//
+// They rely on the shipped default trusted set, 127.0.0.0/8 + ::1/128, so a
+// loopback RemoteAddr is a TRUSTED peer here with no env manipulation.
+
+// forwardedAddressRequest is a request as a trusted ingress proxy on loopback
+// would deliver it.
+func forwardedAddressRequest(t *testing.T, headers map[string]string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/auth/network-create", strings.NewReader("{}"))
+	req.RemoteAddr = "127.0.0.1:52344"
+	for header, value := range headers {
+		req.Header.Set(header, value)
+	}
+	return req
+}
+
+// runWrapped drives the real handler wrappers and reports what the client would
+// have received, plus the client address the impl was handed.
+func runWrapped(req *http.Request) (statusCode int, body string, clientAddress string) {
+	recorder := httptest.NewRecorder()
+	wrap(
+		func(clientSession *session.ClientSession) (string, error) {
+			clientAddress = clientSession.ClientAddress
+			return "ok", nil
+		},
+		recorder,
+		req,
+	)
+	return recorder.Code, strings.TrimRight(recorder.Body.String(), "\n"), clientAddress
+}
+
+func runWrappedWithInput(req *http.Request) (statusCode int, body string, clientAddress string) {
+	recorder := httptest.NewRecorder()
+	wrapWithInput(
+		RequestBodyFormatter,
+		func(input map[string]any, clientSession *session.ClientSession) (string, error) {
+			clientAddress = clientSession.ClientAddress
+			return "ok", nil
+		},
+		recorder,
+		req,
+	)
+	return recorder.Code, strings.TrimRight(recorder.Body.String(), "\n"), clientAddress
+}
+
+// TestEnumeratedProxySendingOnlyBareXForwardedForIsNotA500 is the proof
+// obligation for this fix, stated the way the defect was.
+func TestEnumeratedProxySendingOnlyBareXForwardedForIsNotA500(t *testing.T) {
+	for _, shape := range []struct {
+		what    string
+		headers map[string]string
+	}{
+		{
+			"stock nginx / ALB / CloudFront / Cloudflare: bare X-Forwarded-For, no source port",
+			map[string]string{"X-Forwarded-For": "203.0.113.9"},
+		},
+		{
+			"two hops: $proxy_add_x_forwarded_for appends, producing a comma",
+			map[string]string{"X-Forwarded-For": "203.0.113.9, 127.0.0.9"},
+		},
+		{
+			"a client that prepended its own X-Forwarded-For before the proxy appended",
+			map[string]string{"X-Forwarded-For": "6.6.6.6, 203.0.113.9"},
+		},
+		{
+			"a proxy that writes ip:port into X-Forwarded-For",
+			map[string]string{"X-Forwarded-For": "203.0.113.9:41001"},
+		},
+		{
+			"a forwarding header this service cannot read at all",
+			map[string]string{"X-Forwarded-For": "not-an-address"},
+		},
+		{
+			"an X-UR-Forwarded-For chain",
+			map[string]string{"X-UR-Forwarded-For": "6.6.6.6:1, 203.0.113.9:41001"},
+		},
+	} {
+		for _, wrapper := range []struct {
+			name string
+			run  func(*http.Request) (int, string, string)
+		}{
+			{"wrap", runWrapped},
+			{"wrapWithInput", runWrappedWithInput},
+		} {
+			statusCode, body, _ := wrapper.run(forwardedAddressRequest(t, shape.headers))
+			if statusCode == http.StatusInternalServerError {
+				t.Fatalf(
+					"%s: %s answered HTTP 500 (%q).\n"+
+						"An operator who read the unenumerated-proxy report, added their "+
+						"ingress proxy's subnet to BRINGYOUR_TRUSTED_PROXY_CIDRS and changed "+
+						"nothing else has just taken the entire api down -- every endpoint, "+
+						"not only signup",
+					wrapper.name, shape.what, body,
+				)
+			}
+			if statusCode != http.StatusOK {
+				t.Fatalf("%s: %s answered HTTP %d (%q), want 200", wrapper.name, shape.what, statusCode, body)
+			}
+		}
+	}
+}
+
+// TestEnumeratingAProxyActuallySeparatesItsClients: not answering 500 is only
+// half of it. If enumerating the proxy left every client resolving to the
+// proxy's own address, the operator would have followed the report, kept the
+// api up, and still had one 5-per-24h signup budget for the whole fleet -- the
+// exact bug the report exists to name.
+func TestEnumeratingAProxyActuallySeparatesItsClients(t *testing.T) {
+	_, _, first := runWrapped(forwardedAddressRequest(t, map[string]string{
+		"X-Forwarded-For": "203.0.113.9",
+	}))
+	_, _, second := runWrapped(forwardedAddressRequest(t, map[string]string{
+		"X-Forwarded-For": "198.51.100.20",
+	}))
+
+	if first == second {
+		t.Fatalf(
+			"two clients behind the enumerated proxy both reached the handler with "+
+				"ClientAddress=%q; every per-address rate limit in the service is now "+
+				"one fleet-wide limit",
+			first,
+		)
+	}
+	for _, got := range []string{first, second} {
+		if strings.HasPrefix(got, "127.0.0.1:") {
+			t.Fatalf(
+				"a client behind the enumerated proxy reached the handler with the "+
+					"proxy's own address %q; the forwarded identity was discarded",
+				got,
+			)
+		}
+	}
+	if first != "203.0.113.9:0" {
+		t.Fatalf("handler saw ClientAddress=%q, want 203.0.113.9:0", first)
+	}
+}
+
+// TestForgedForwardedAddressDoesNotReachTheHandler is the safety half at the
+// same boundary. X-Forwarded-For is client-supplied; a proxy that appends means
+// everything left of the appended entry is the client's own text. If that
+// reached the handler, every client behind the proxy would pick its own
+// rate-limit bucket -- strictly worse than the shared-budget bug.
+func TestForgedForwardedAddressDoesNotReachTheHandler(t *testing.T) {
+	_, _, clientAddress := runWrapped(forwardedAddressRequest(t, map[string]string{
+		"X-Forwarded-For": "6.6.6.6, 203.0.113.9",
+	}))
+	if strings.HasPrefix(clientAddress, "6.6.6.6") {
+		t.Fatalf(
+			"a client behind the trusted proxy prepended X-Forwarded-For: 6.6.6.6 and "+
+				"the handler was given ClientAddress=%q. It just chose its own rate-limit "+
+				"bucket",
+			clientAddress,
+		)
+	}
+	if clientAddress != "203.0.113.9:0" {
+		t.Fatalf("handler saw ClientAddress=%q, want the address the proxy appended, 203.0.113.9:0", clientAddress)
+	}
+
+	// an unreadable header must fall back to the peer, never to whatever the
+	// client wrote
+	_, _, clientAddress = runWrapped(forwardedAddressRequest(t, map[string]string{
+		"X-Forwarded-For": "not-an-address",
+	}))
+	if clientAddress != "127.0.0.1:52344" {
+		t.Fatalf(
+			"an unreadable forwarding header gave the handler ClientAddress=%q, want the "+
+				"peer address 127.0.0.1:52344",
+			clientAddress,
+		)
+	}
+}
+
+// TestUntrustedPeerForwardingHeaderIsIgnoredAtTheHandler: the whole contract
+// only holds because the peer must be enumerated first. A request arriving from
+// a non-loopback peer carries no authority at all, whatever it claims.
+func TestUntrustedPeerForwardingHeaderIsIgnoredAtTheHandler(t *testing.T) {
+	req := forwardedAddressRequest(t, map[string]string{"X-Forwarded-For": "203.0.113.9"})
+	req.RemoteAddr = "192.0.2.44:54321"
+
+	statusCode, body, clientAddress := runWrapped(req)
+	if statusCode != http.StatusOK {
+		t.Fatalf("untrusted peer answered HTTP %d (%q), want 200", statusCode, body)
+	}
+	if clientAddress != "192.0.2.44:54321" {
+		t.Fatalf(
+			"a forwarding header from an UNTRUSTED peer was honored: the handler saw "+
+				"ClientAddress=%q. Any client could now claim any source address and step "+
+				"outside every per-address rate limit in the service",
+			clientAddress,
+		)
+	}
+}

--- a/router/handler_forwarded_address_test.go
+++ b/router/handler_forwarded_address_test.go
@@ -204,6 +204,85 @@ func TestForgedForwardedAddressDoesNotReachTheHandler(t *testing.T) {
 	}
 }
 
+// TestSecondForwardingHeaderDoesNotReachTheHandler is the HTTP-boundary form of
+// session.TestASecondForwardingHeaderCannotChooseTheBucket.
+//
+// A proxy overwrites the header it sets and passes the client's other headers
+// through by default, so "the api reads two forwarding headers and honors the
+// first one it finds" was a bucket the client could pick, on whichever
+// deployment shape did not own that header. Asserted here because the value
+// that matters is the ClientAddress the impl is HANDED -- that is what every
+// per-address limit keys on -- and because the refusal must not have turned
+// into the 500 this suite exists to prevent.
+func TestSecondForwardingHeaderDoesNotReachTheHandler(t *testing.T) {
+	for _, shape := range []struct {
+		what    string
+		headers map[string]string
+	}{
+		{
+			"proxy owns X-Forwarded-For, client adds X-UR-Forwarded-For",
+			map[string]string{
+				"X-Forwarded-For":    "203.0.113.9",
+				"X-UR-Forwarded-For": "6.6.6.6:1234",
+			},
+		},
+		{
+			"proxy owns X-UR-Forwarded-For, client adds X-Forwarded-For",
+			map[string]string{
+				"X-UR-Forwarded-For": "203.0.113.9:41001",
+				"X-Forwarded-For":    "6.6.6.6",
+			},
+		},
+	} {
+		for _, run := range []struct {
+			wrapper string
+			call    func(*http.Request) (int, string, string)
+		}{
+			{"wrap", runWrapped},
+			{"wrapWithInput", runWrappedWithInput},
+		} {
+			statusCode, body, clientAddress := run.call(forwardedAddressRequest(t, shape.headers))
+			if statusCode != http.StatusOK {
+				t.Fatalf("%s: %s answered HTTP %d (%q), want 200", shape.what, run.wrapper, statusCode, body)
+			}
+			if strings.HasPrefix(clientAddress, "6.6.6.6") {
+				t.Fatalf(
+					"%s: %s handed the impl ClientAddress=%q. A client behind the trusted "+
+						"proxy just chose its own rate-limit bucket by setting the forwarding "+
+						"header the proxy does not overwrite",
+					shape.what, run.wrapper, clientAddress,
+				)
+			}
+			if clientAddress != "127.0.0.1:52344" {
+				t.Fatalf(
+					"%s: %s handed the impl ClientAddress=%q, want the peer address "+
+						"127.0.0.1:52344: with two headers naming two clients neither can be "+
+						"shown to be the proxy's",
+					shape.what, run.wrapper, clientAddress,
+				)
+			}
+		}
+	}
+
+	// and the deployment whose proxy sets BOTH headers correctly keeps the
+	// address and the port it had before the rule above existed
+	statusCode, body, clientAddress := runWrapped(forwardedAddressRequest(t, map[string]string{
+		"X-UR-Forwarded-For": "203.0.113.9:41001",
+		"X-Forwarded-For":    "6.6.6.6, 203.0.113.9",
+	}))
+	if statusCode != http.StatusOK {
+		t.Fatalf("a proxy setting both headers consistently answered HTTP %d (%q), want 200", statusCode, body)
+	}
+	if clientAddress != "203.0.113.9:41001" {
+		t.Fatalf(
+			"a proxy that sets both headers correctly handed the impl ClientAddress=%q, "+
+				"want 203.0.113.9:41001. Refusing on any difference between the two headers "+
+				"would take the client address away from a working deployment",
+			clientAddress,
+		)
+	}
+}
+
 // TestUntrustedPeerForwardingHeaderIsIgnoredAtTheHandler: the whole contract
 // only holds because the peer must be enumerated first. A request arriving from
 // a non-loopback peer carries no authority at all, whatever it claims.

--- a/router/handler_utils.go
+++ b/router/handler_utils.go
@@ -127,8 +127,14 @@ func WrapRequireAuth[R any](
 			}
 			r, err := impl(session)
 			if err != nil {
-				// wrap the error to tag the impl
-				err = fmt.Errorf("[%s]%s", implName(impl), err)
+				// wrap the error to tag the impl. %w, not %s: RaiseHttpError
+				// reads Retry-After off the error with errors.As, and %s
+				// flattens the error to text and breaks that chain. The
+				// client-facing message is identical either way -- the tag is
+				// peeled by httpErrorCodeRegex -- so the only thing %s changed
+				// was silently dropping the retry hint from any rate limit
+				// reached through an authenticated route.
+				err = fmt.Errorf("[%s]%w", implName(impl), err)
 			}
 			return r, err
 		},
@@ -153,8 +159,14 @@ func WrapRequireClient[R any](
 			}
 			r, err := impl(session)
 			if err != nil {
-				// wrap the error to tag the impl
-				err = fmt.Errorf("[%s]%s", implName(impl), err)
+				// wrap the error to tag the impl. %w, not %s: RaiseHttpError
+				// reads Retry-After off the error with errors.As, and %s
+				// flattens the error to text and breaks that chain. The
+				// client-facing message is identical either way -- the tag is
+				// peeled by httpErrorCodeRegex -- so the only thing %s changed
+				// was silently dropping the retry hint from any rate limit
+				// reached through an authenticated route.
+				err = fmt.Errorf("[%s]%w", implName(impl), err)
 			}
 			return r, err
 		},
@@ -174,8 +186,14 @@ func WrapNoAuth[R any](
 		func(session *session.ClientSession) (R, error) {
 			r, err := impl(session)
 			if err != nil {
-				// wrap the error to tag the impl
-				err = fmt.Errorf("[%s]%s", implName(impl), err)
+				// wrap the error to tag the impl. %w, not %s: RaiseHttpError
+				// reads Retry-After off the error with errors.As, and %s
+				// flattens the error to text and breaks that chain. The
+				// client-facing message is identical either way -- the tag is
+				// peeled by httpErrorCodeRegex -- so the only thing %s changed
+				// was silently dropping the retry hint from any rate limit
+				// reached through an authenticated route.
+				err = fmt.Errorf("[%s]%w", implName(impl), err)
 			}
 			return r, err
 		},

--- a/router/handler_utils.go
+++ b/router/handler_utils.go
@@ -401,6 +401,17 @@ func RaiseHttpError(err error, w http.ResponseWriter) (statusError bool) {
 		statusError = true
 	}
 
+	// A rate limit knows when the caller may try again; without the header the
+	// client can only guess, and guessing early costs it more budget. Read
+	// through a one-method interface so the direction of the import stays as it
+	// is: model does not import the router.
+	var retryAfter interface{ RetryAfterSeconds() int }
+	if errors.As(err, &retryAfter) {
+		if seconds := retryAfter.RetryAfterSeconds(); 0 < seconds {
+			w.Header().Set("Retry-After", strconv.Itoa(seconds))
+		}
+	}
+
 	http.Error(w, message, statusCode)
 	return
 }

--- a/router/handler_utils.go
+++ b/router/handler_utils.go
@@ -105,6 +105,23 @@ func wrap[R any](
 	writeJsonResponse(w, result)
 }
 
+// tagImplError prefixes an impl error with the impl name, the "[tag]" form
+// RaiseHttpError's httpErrorCodeRegex peels back off before the message reaches
+// the client.
+//
+// %w, not %s. RaiseHttpError reads the retry hint off a rate limit with
+// errors.As, and %s flattens the error to text, which breaks that chain. The
+// client-facing message is byte-identical either way, so the only visible
+// effect of %s was a 429 that silently lost its Retry-After -- a defect with no
+// symptom at the status code. This is one function rather than three copies so
+// that a single test can pin all three wrappers.
+func tagImplError[R any](impl ImplFunction[R], err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("[%s]%w", implName(impl), err)
+}
+
 func implName[R any](impl ImplFunction[R]) string {
 	name := runtime.FuncForPC(reflect.ValueOf(impl).Pointer()).Name()
 	// remove all /vXXXX paths in the canonical module
@@ -126,17 +143,7 @@ func WrapRequireAuth[R any](
 				return empty, fmt.Errorf("%d Not authorized.", http.StatusUnauthorized)
 			}
 			r, err := impl(session)
-			if err != nil {
-				// wrap the error to tag the impl. %w, not %s: RaiseHttpError
-				// reads Retry-After off the error with errors.As, and %s
-				// flattens the error to text and breaks that chain. The
-				// client-facing message is identical either way -- the tag is
-				// peeled by httpErrorCodeRegex -- so the only thing %s changed
-				// was silently dropping the retry hint from any rate limit
-				// reached through an authenticated route.
-				err = fmt.Errorf("[%s]%w", implName(impl), err)
-			}
-			return r, err
+			return r, tagImplError(impl, err)
 		},
 		w,
 		req,
@@ -158,17 +165,7 @@ func WrapRequireClient[R any](
 				return empty, fmt.Errorf("%d Not authorized.", http.StatusUnauthorized)
 			}
 			r, err := impl(session)
-			if err != nil {
-				// wrap the error to tag the impl. %w, not %s: RaiseHttpError
-				// reads Retry-After off the error with errors.As, and %s
-				// flattens the error to text and breaks that chain. The
-				// client-facing message is identical either way -- the tag is
-				// peeled by httpErrorCodeRegex -- so the only thing %s changed
-				// was silently dropping the retry hint from any rate limit
-				// reached through an authenticated route.
-				err = fmt.Errorf("[%s]%w", implName(impl), err)
-			}
-			return r, err
+			return r, tagImplError(impl, err)
 		},
 		w,
 		req,
@@ -185,17 +182,7 @@ func WrapNoAuth[R any](
 	wrap(
 		func(session *session.ClientSession) (R, error) {
 			r, err := impl(session)
-			if err != nil {
-				// wrap the error to tag the impl. %w, not %s: RaiseHttpError
-				// reads Retry-After off the error with errors.As, and %s
-				// flattens the error to text and breaks that chain. The
-				// client-facing message is identical either way -- the tag is
-				// peeled by httpErrorCodeRegex -- so the only thing %s changed
-				// was silently dropping the retry hint from any rate limit
-				// reached through an authenticated route.
-				err = fmt.Errorf("[%s]%w", implName(impl), err)
-			}
-			return r, err
+			return r, tagImplError(impl, err)
 		},
 		w,
 		req,

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -536,6 +536,146 @@ func TestProxyReportPruneScanStaysAmortized(t *testing.T) {
 	}
 }
 
+// TestReportSlotsAreNotBoughtByRotatingSourceAddresses: the suppression key is
+// a peer NETWORK, not a peer address, so rotating source addresses inside one
+// network buys no fresh report slots.
+//
+// Measured before this key was bucketed: one unenumerated-proxy report is ~1.8
+// KB, and a caller rotating addresses sustained the full cap of 1024 report
+// lines per minute -- roughly 1.8 MB/min, 2.6 GB/day of glog.Errorf from one
+// caller. The cost of that was a single ipv6 /64, which every residential
+// allocation is, because the key unmapped the peer but did not mask it. It is
+// only reachable on the UNTRUSTED-peer path (reportUnenumeratedProxy), i.e. an
+// api reachable without a proxy in front of it; behind an enumerated proxy the
+// peer is one address and the ceiling was already one line per minute.
+//
+// The prefixes are the ones server.ClientIpHashForAddr already uses to decide
+// what counts as one client (/29 v4, /56 v6). Nothing in ip.go changes; this
+// reuses the same answer so a caller who cannot buy extra rate-limit budget by
+// rotating addresses cannot buy extra log volume with it either.
+func TestReportSlotsAreNotBoughtByRotatingSourceAddresses(t *testing.T) {
+	captureProxyReports(t)
+	now := time.Now()
+
+	// a whole ipv4 /29, one address at a time
+	emitted := 0
+	for i := 0; i < 8; i += 1 {
+		if shouldReportProxy(proxyReportKey{
+			peer: netip.AddrFrom4([4]byte{203, 0, 113, byte(i)}),
+			kind: proxyReportUnenumerated,
+		}, now) {
+			emitted += 1
+		}
+	}
+	if emitted != 1 {
+		t.Fatalf(
+			"every address in one ipv4 /29 was reported separately (%d lines): a caller "+
+				"buys a fresh report slot per address, and the ceiling is %d lines per "+
+				"interval instead of one",
+			emitted, proxyReportedMax,
+		)
+	}
+
+	// the next /29 is a different network and must still be named -- masking
+	// that silenced neighbouring proxies would be a worse bug than the flood
+	if !shouldReportProxy(proxyReportKey{
+		peer: netip.AddrFrom4([4]byte{203, 0, 113, 8}),
+		kind: proxyReportUnenumerated,
+	}, now) {
+		t.Fatal(
+			"the adjacent /29 was suppressed by its neighbour: the peer bucket is coarser " +
+				"than the one the rest of the service uses for a client, and an operator " +
+				"cannot see which proxies are unenumerated",
+		)
+	}
+
+	// an ipv6 /64 -- the cheapest thing an attacker can have -- across four
+	// simulated minutes. One /56 is one slot, so the ceiling is one line per
+	// interval no matter how many addresses are used.
+	resetProxyReports()
+	perMinute := []int{}
+	n := 0
+	for minute := 0; minute < 4; minute += 1 {
+		at := now.Add(time.Duration(minute) * proxyReportInterval)
+		lines := 0
+		for i := 0; i < 4096; i += 1 {
+			n += 1
+			peer := netip.AddrFrom16([16]byte{
+				0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+				byte(n >> 56), byte(n >> 48), byte(n >> 40), byte(n >> 32),
+				byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n),
+			})
+			if shouldReportProxy(proxyReportKey{peer: peer, kind: proxyReportUnenumerated}, at) {
+				lines += 1
+			}
+		}
+		perMinute = append(perMinute, lines)
+	}
+	for minute, lines := range perMinute {
+		if lines != 1 {
+			t.Fatalf(
+				"4096 addresses from ONE ipv6 /64 produced %d report lines in simulated "+
+					"minute %d (all minutes: %v), want 1 each. A single residential ipv6 "+
+					"allocation can drive the error log at %d lines per interval",
+				lines, minute, perMinute, lines,
+			)
+		}
+	}
+
+	// and the report set never had to hold more than the one entry
+	proxyReportMutex.Lock()
+	size := len(proxyReportedAt)
+	proxyReportMutex.Unlock()
+	if size != 1 {
+		t.Fatalf(
+			"16384 addresses from one ipv6 /64 left %d entries in the suppression map, "+
+				"want 1: rotating addresses still grows it",
+			size,
+		)
+	}
+}
+
+// TestGenuineReportSurvivesAFloodOfDistinctPeers is the liveness half of the
+// bound above, and the property that makes every suppression tier in
+// shouldReportProxy acceptable.
+//
+// Bounding a log is easy; bounding it without losing the one line an operator
+// needs is the requirement. The deployment this whole file exists to diagnose
+// is one whose ingress proxy is not enumerated -- that peer is essentially all
+// of the traffic -- so it must keep being named every interval even while a
+// caller with a large address range keeps the suppression map full.
+func TestGenuineReportSurvivesAFloodOfDistinctPeers(t *testing.T) {
+	captureProxyReports(t)
+	now := time.Now()
+
+	wedged := proxyReportKey{peer: netip.MustParseAddr("198.51.100.7"), kind: proxyReportUnenumerated}
+	genuine := 0
+	n := 0
+	for minute := 0; minute < 5; minute += 1 {
+		at := now.Add(time.Duration(minute) * proxyReportInterval)
+		if shouldReportProxy(wedged, at) {
+			genuine += 1
+		}
+		// distinct /29s, so each one is a genuinely different network and the
+		// bucketing above does not do the work for us
+		for i := 0; i < 4000; i += 1 {
+			n += 1
+			shouldReportProxy(proxyReportKey{
+				peer: netip.AddrFrom4([4]byte{10, byte(n >> 11), byte(n >> 3), 0}),
+				kind: proxyReportUnenumerated,
+			}, at)
+		}
+	}
+	if genuine != 5 {
+		t.Fatalf(
+			"the wedged proxy was named %d times across 5 intervals while a flood of "+
+				"distinct peers ran, want 5. The report an operator needs is the one that "+
+				"went missing, and the failure it diagnoses is invisible without it",
+			genuine,
+		)
+	}
+}
+
 // TestNoProxyReportWithoutForwardingHeaders: a direct client that sends no
 // forwarding header is the ordinary case for a service reachable without a
 // proxy. Reporting it would bury the real signal.

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -1,0 +1,402 @@
+package session
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression suite for wrongful 429/503 on account creation.
+//
+// Every per-address budget in the service keys off the address
+// ResolveClientAddress returns: the account-creation limit (5 per 24h,
+// model/network_create_rate_limit.go) and the auth-attempt limit (5 per 5min,
+// model/auth_model_attempt.go). If the resolver hands back the ingress proxy's
+// own address instead of the client's, all of those budgets collapse into ONE
+// budget for the whole deployment, and legitimate first-time users are refused
+// with "429 You have reached the maximum number of account creations for
+// today." or "503 User auth attempts exceeded limits." for something five
+// strangers did.
+
+const (
+	// the ingress proxy's own address on a container bridge network
+	ingressProxyAddress = "172.18.0.7:52344"
+	ingressProxyCidr    = "172.16.0.0/12"
+)
+
+func ingressRequest(clientIp string, clientPort string) *http.Request {
+	req := httptest.NewRequest("POST", "/auth/network-create", nil)
+	req.RemoteAddr = ingressProxyAddress
+	req.Header.Set("X-Forwarded-For", clientIp)
+	req.Header.Set("X-Forwarded-Source-Port", clientPort)
+	return req
+}
+
+// TestResolveClientAddressSeparatesClientsBehindTrustedIngressProxy is the
+// highest-value assertion in this suite: two unrelated signups arriving through
+// the same proxy must not resolve to the same address. A resolver that returns
+// the proxy address for both gives the entire fleet a single 5-per-24h signup
+// budget.
+func TestResolveClientAddressSeparatesClientsBehindTrustedIngressProxy(t *testing.T) {
+	trusted := []netip.Prefix{netip.MustParsePrefix(ingressProxyCidr)}
+
+	first, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted)
+	if err != nil {
+		t.Fatalf("first client: err=%v", err)
+	}
+	second, err := ResolveClientAddress(ingressRequest("198.51.100.20", "41002"), trusted)
+	if err != nil {
+		t.Fatalf("second client: err=%v", err)
+	}
+
+	if first == second {
+		t.Fatalf(
+			"two different clients behind the ingress proxy both resolved to %q: "+
+				"they share one rate-limit budget, so every signup on the deployment "+
+				"competes for the same 5 per 24h",
+			first,
+		)
+	}
+	for _, got := range []string{first, second} {
+		if got == ingressProxyAddress {
+			t.Fatalf(
+				"client resolved to the proxy's own address %q; the forwarded client "+
+					"identity was discarded",
+				got,
+			)
+		}
+	}
+	if first != "203.0.113.9:41001" {
+		t.Fatalf("first client resolved to %q, want 203.0.113.9:41001", first)
+	}
+	if second != "198.51.100.20:41002" {
+		t.Fatalf("second client resolved to %q, want 198.51.100.20:41002", second)
+	}
+}
+
+// TestNewClientSessionFromRequestUsesConfiguredTrustedProxies pins the wiring,
+// not just the helper. Handlers never call ResolveClientAddress directly; they
+// get a session from NewClientSessionFromRequest (router/handler_utils.go:196).
+// If that constructor stops consulting the forwarding headers, the helper above
+// keeps passing while every real request collapses onto the proxy.
+func TestNewClientSessionFromRequestUsesConfiguredTrustedProxies(t *testing.T) {
+	original := trustedProxyPrefixes
+	defer func() { trustedProxyPrefixes = original }()
+	trustedProxyPrefixes = func() []netip.Prefix {
+		return []netip.Prefix{netip.MustParsePrefix(ingressProxyCidr)}
+	}
+
+	firstSession, err := NewClientSessionFromRequest(ingressRequest("203.0.113.9", "41001"))
+	if err != nil {
+		t.Fatalf("first session: %v", err)
+	}
+	defer firstSession.Cancel()
+	secondSession, err := NewClientSessionFromRequest(ingressRequest("198.51.100.20", "41002"))
+	if err != nil {
+		t.Fatalf("second session: %v", err)
+	}
+	defer secondSession.Cancel()
+
+	if firstSession.ClientAddress == secondSession.ClientAddress {
+		t.Fatalf(
+			"NewClientSessionFromRequest gave both clients ClientAddress=%q; "+
+				"every rate limit keyed on the session address is now fleet-wide",
+			firstSession.ClientAddress,
+		)
+	}
+	if firstSession.ClientAddress != "203.0.113.9:41001" {
+		t.Fatalf("first session ClientAddress=%q, want 203.0.113.9:41001", firstSession.ClientAddress)
+	}
+}
+
+// TestUnenumeratedIngressProxyCollapsesEveryClientOntoOneAddress pins the
+// shipped default so it cannot drift silently.
+//
+// BRINGYOUR_TRUSTED_PROXY_CIDRS defaults to loopback only, and it is set
+// nowhere in this repository other than its own const declaration. A deployment
+// whose ingress proxy is NOT on loopback -- any container-bridge or
+// separate-host proxy -- therefore hits the branch asserted below, and every
+// client on the deployment shares one address and one budget. That is a
+// deployment configuration gap, not a defect in this function: trusting an
+// unenumerated private range by default would be strictly worse.
+//
+// READ THIS BEFORE TREATING A GREEN RUN AS COVERAGE. This test is BLIND to the
+// actual remedy. The fix is to set BRINGYOUR_TRUSTED_PROXY_CIDRS on the api
+// service to the ingress proxy's subnet, and a Go test process reads an unset
+// env var no matter what the deployment does -- so this test keeps passing,
+// unchanged, both before and after the fleet-wide 429 is fixed. It detects
+// exactly one thing: a change to the compiled-in default. Whether the
+// deployment enumerates its proxy cannot be observed from any test in this
+// repository.
+//
+// It cannot be observed from a test, but it IS now observable from the running
+// service: reaching the branch below emits an operator-facing error naming the
+// peer, which is what TestUnenumeratedIngressProxyIsReportedLoudly pins. That
+// report is the reason a deployment can no longer be wedged silently; this test
+// still deliberately does not assert the deployment is configured, because it
+// cannot.
+func TestUnenumeratedIngressProxyCollapsesEveryClientOntoOneAddress(t *testing.T) {
+	resetUnenumeratedProxyReports()
+	defaults := trustedProxyPrefixes()
+
+	for _, prefix := range defaults {
+		if prefix.Addr().IsLoopback() {
+			continue
+		}
+		t.Fatalf(
+			"default trusted proxy set contains the non-loopback prefix %s; "+
+				"if that is intentional, update the deployment note on this test",
+			prefix,
+		)
+	}
+
+	first, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), defaults)
+	if err != nil {
+		t.Fatalf("first client: %v", err)
+	}
+	second, err := ResolveClientAddress(ingressRequest("198.51.100.20", "41002"), defaults)
+	if err != nil {
+		t.Fatalf("second client: %v", err)
+	}
+	if first != ingressProxyAddress || second != ingressProxyAddress {
+		t.Fatalf(
+			"untrusted ingress proxy no longer collapses clients (%q, %q); the "+
+				"default trusted set changed -- revisit the deployment note",
+			first, second,
+		)
+	}
+}
+
+// capturedProxyReport is one operator-facing report of an unenumerated proxy.
+type capturedProxyReport struct {
+	peer   netip.Addr
+	header string
+}
+
+// captureProxyReports swaps the reporter for the duration of a test and clears
+// the suppression state on both sides, so one test cannot silence the next.
+func captureProxyReports(t *testing.T) *[]capturedProxyReport {
+	t.Helper()
+	reports := []capturedProxyReport{}
+	original := reportUnenumeratedProxy
+	resetUnenumeratedProxyReports()
+	reportUnenumeratedProxy = func(peer netip.Addr, header string, trusted []netip.Prefix) {
+		if !shouldReportUnenumeratedProxy(peer, time.Now()) {
+			return
+		}
+		reports = append(reports, capturedProxyReport{peer: peer, header: header})
+	}
+	t.Cleanup(func() {
+		reportUnenumeratedProxy = original
+		resetUnenumeratedProxyReports()
+	})
+	return &reports
+}
+
+// TestUnenumeratedIngressProxyIsReportedLoudly is the test for the highest-value
+// change in this fix.
+//
+// The wedged deployment that motivated this suite ran for an unknown length of
+// time with BRINGYOUR_TRUSTED_PROXY_CIDRS unset, every client collapsed onto the
+// ingress proxy's address, and every signup competing for one 5-per-24h budget.
+// Nothing anywhere said so. The only symptom was users being refused, which is
+// indistinguishable from the abuse the limiter exists to stop.
+//
+// A request whose peer is not trusted but which carries a forwarding header is
+// exactly that condition: something upstream believes it is a proxy this service
+// trusts, and this service disagrees. That must be reported. It must NOT be
+// auto-trusted -- see TestUnenumeratedProxyReportDoesNotTrustThePeer.
+func TestUnenumeratedIngressProxyIsReportedLoudly(t *testing.T) {
+	reports := captureProxyReports(t)
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
+	if _, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(*reports) != 1 {
+		t.Fatalf(
+			"an untrusted peer sent X-Forwarded-For and %d reports were emitted, want 1: "+
+				"the deployment can be wedged onto a single client address with nothing "+
+				"in the log saying so",
+			len(*reports),
+		)
+	}
+	if got := (*reports)[0].peer.String(); got != "172.18.0.7" {
+		t.Fatalf("report named peer %q, want the actual TCP peer 172.18.0.7", got)
+	}
+	if (*reports)[0].header != "X-Forwarded-For" {
+		t.Fatalf("report named header %q, want X-Forwarded-For", (*reports)[0].header)
+	}
+
+	// X-UR-Forwarded-For is the other header a trusted peer is allowed to set,
+	// so it has to be detected too
+	urRequest := httptest.NewRequest("POST", "/auth/network-create", nil)
+	urRequest.RemoteAddr = "172.18.0.9:53001"
+	urRequest.Header.Set("X-UR-Forwarded-For", "203.0.113.9:41001")
+	if _, err := ResolveClientAddress(urRequest, trusted); err != nil {
+		t.Fatalf("resolve ur-forwarded: %v", err)
+	}
+	if len(*reports) != 2 {
+		t.Fatalf("X-UR-Forwarded-For from an untrusted peer produced %d reports total, want 2", len(*reports))
+	}
+	if (*reports)[1].header != "X-UR-Forwarded-For" {
+		t.Fatalf("second report named header %q, want X-UR-Forwarded-For", (*reports)[1].header)
+	}
+}
+
+// TestUnenumeratedProxyReportDoesNotTrustThePeer is the safety half of the
+// change above. Reporting the misconfiguration must not repair it: honoring a
+// forwarding header from a peer the deployment never enumerated would let any
+// client claim any source address and walk out of every per-address limit in
+// the service. The report is loud; the resolution is unchanged.
+func TestUnenumeratedProxyReportDoesNotTrustThePeer(t *testing.T) {
+	captureProxyReports(t)
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
+	got, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != ingressProxyAddress {
+		t.Fatalf(
+			"an untrusted peer's forwarding header was honored: resolved to %q. Any "+
+				"client could now claim any source address and step outside every "+
+				"per-address rate limit",
+			got,
+		)
+	}
+}
+
+// TestUnenumeratedProxyReportIsRateLimited: the report is emitted on a request
+// path, so an unbounded one is a log-flooding hole -- any client can set
+// X-Forwarded-For on a directly reachable api. Once per distinct peer, then no
+// more than once per interval.
+func TestUnenumeratedProxyReportIsRateLimited(t *testing.T) {
+	reports := captureProxyReports(t)
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
+	for i := 0; i < 50; i += 1 {
+		if _, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted); err != nil {
+			t.Fatalf("resolve %d: %v", i, err)
+		}
+	}
+	if len(*reports) != 1 {
+		t.Fatalf(
+			"50 requests from one untrusted peer produced %d reports, want 1: a client "+
+				"can flood the log by repeating a request with a forwarding header",
+			len(*reports),
+		)
+	}
+
+	// a genuinely different peer is worth naming once
+	other := httptest.NewRequest("POST", "/auth/network-create", nil)
+	other.RemoteAddr = "172.18.0.8:52345"
+	other.Header.Set("X-Forwarded-For", "203.0.113.9")
+	other.Header.Set("X-Forwarded-Source-Port", "41001")
+	if _, err := ResolveClientAddress(other, trusted); err != nil {
+		t.Fatalf("resolve other peer: %v", err)
+	}
+	if len(*reports) != 2 {
+		t.Fatalf(
+			"a second, distinct untrusted peer produced %d reports total, want 2: an "+
+				"operator cannot see which proxies are unenumerated",
+			len(*reports),
+		)
+	}
+}
+
+// TestUnenumeratedProxyReportSurvivesTheBoundedPeerSet pins the suppression
+// state directly. The per-peer set is bounded, so a caller cycling source
+// addresses cannot grow it without limit -- but once it is full the report must
+// keep firing on the interval, otherwise a deployment that becomes wedged later
+// goes quiet again, which is the exact failure this change exists to prevent.
+func TestUnenumeratedProxyReportSurvivesTheBoundedPeerSet(t *testing.T) {
+	captureProxyReports(t)
+
+	peer := netip.MustParseAddr("172.18.0.7")
+	now := time.Now()
+	if !shouldReportUnenumeratedProxy(peer, now) {
+		t.Fatal("the first sighting of a peer was suppressed")
+	}
+	if shouldReportUnenumeratedProxy(peer, now.Add(unenumeratedProxyReportInterval-time.Second)) {
+		t.Fatal("a repeat inside the interval was reported; the report can be flooded")
+	}
+	if !shouldReportUnenumeratedProxy(peer, now.Add(unenumeratedProxyReportInterval)) {
+		t.Fatal("no report after the interval elapsed; a wedged deployment goes silent")
+	}
+
+	// fill the bounded set, then confirm the interval path still fires
+	resetUnenumeratedProxyReports()
+	for i := 0; i < unenumeratedProxyReportedMax+16; i += 1 {
+		shouldReportUnenumeratedProxy(netip.AddrFrom4([4]byte{10, byte(i >> 8), byte(i), 1}), now)
+	}
+	unenumeratedProxyMutex.Lock()
+	size := len(unenumeratedProxyReported)
+	unenumeratedProxyMutex.Unlock()
+	if unenumeratedProxyReportedMax < size {
+		t.Fatalf(
+			"the per-peer suppression set grew to %d entries, cap is %d: a caller "+
+				"cycling source addresses can grow server memory without limit",
+			size, unenumeratedProxyReportedMax,
+		)
+	}
+	if !shouldReportUnenumeratedProxy(netip.MustParseAddr("198.51.100.1"), now.Add(unenumeratedProxyReportInterval)) {
+		t.Fatal("with the peer set full, the interval path stopped reporting entirely")
+	}
+}
+
+// TestNoProxyReportWithoutForwardingHeaders: a direct client that sends no
+// forwarding header is the ordinary case for a service reachable without a
+// proxy. Reporting it would bury the real signal.
+func TestNoProxyReportWithoutForwardingHeaders(t *testing.T) {
+	reports := captureProxyReports(t)
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
+	direct := httptest.NewRequest("POST", "/auth/network-create", nil)
+	direct.RemoteAddr = "203.0.113.9:41001"
+	got, err := ResolveClientAddress(direct, trusted)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != "203.0.113.9:41001" {
+		t.Fatalf("direct client resolved to %q", got)
+	}
+	if len(*reports) != 0 {
+		t.Fatalf("an ordinary direct request emitted %d misconfiguration reports", len(*reports))
+	}
+}
+
+// TestUnenumeratedProxyReportNamesTheEnvironmentVariable pins the operator's
+// only actionable detail. A report that says something is wrong without naming
+// the peer and the variable to set is not the fix -- the deployment sat wedged
+// because nobody knew which knob to turn.
+func TestUnenumeratedProxyReportNamesTheEnvironmentVariable(t *testing.T) {
+	resetUnenumeratedProxyReports()
+	defer resetUnenumeratedProxyReports()
+
+	captured := ""
+	original := glogErrorf
+	glogErrorf = func(format string, args ...any) {
+		captured = fmt.Sprintf(format, args...)
+	}
+	defer func() { glogErrorf = original }()
+
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+	if _, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	for _, want := range []string{"172.18.0.7", trustedProxyCidrsEnvironment, "X-Forwarded-For", "127.0.0.0/8"} {
+		if !strings.Contains(captured, want) {
+			t.Fatalf(
+				"the misconfiguration report does not mention %q; an operator reading it "+
+					"cannot tell which peer to enumerate or where.\nreport: %s",
+				want, captured,
+			)
+		}
+	}
+}

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -664,12 +664,14 @@ func TestGenuineReportSurvivesAFloodOfDistinctPeers(t *testing.T) {
 		if shouldReportProxy(wedged, at) {
 			genuine += 1
 		}
-		// distinct /29s, so each one is a genuinely different network and the
-		// bucketing above does not do the work for us
+		// Four thousand GENUINELY distinct /29s per interval, four times the
+		// map's cap, so the bucketing this test sits next to does none of the
+		// work: {n>>13, n>>5, n<<3} is the big-endian encoding of n into the
+		// 29 network bits, so every n is its own /29.
 		for i := 0; i < 4000; i += 1 {
 			n += 1
 			shouldReportProxy(proxyReportKey{
-				peer: netip.AddrFrom4([4]byte{10, byte(n >> 11), byte(n >> 3), 0}),
+				peer: netip.AddrFrom4([4]byte{10, byte(n >> 13), byte(n >> 5), byte(n << 3)}),
 				kind: proxyReportUnenumerated,
 			}, at)
 		}

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -831,31 +831,74 @@ func TestASecondForwardingHeaderCannotChooseTheBucket(t *testing.T) {
 		proxyValue   string
 		clientHeader string
 		clientValue  string
+		// how many operator reports the shape must produce. 1 where both
+		// headers name a client and the two disagree -- that is a proxy
+		// passing a client header through, and it is actionable. 0 where the
+		// proxy's header names only enumerated hops: see the comment on the
+		// last group of shapes below.
+		wantReports int
 	}{
 		{
 			"proxy owns X-Forwarded-For (Caddy/ALB/CloudFront/Cloudflare), client sends a bare X-UR-Forwarded-For",
 			"X-Forwarded-For", "203.0.113.9",
 			"X-UR-Forwarded-For", "6.6.6.6",
+			1,
 		},
 		{
 			"same, with the ip:port form the old code accepted verbatim",
 			"X-Forwarded-For", "203.0.113.9",
 			"X-UR-Forwarded-For", "6.6.6.6:1234",
+			1,
 		},
 		{
 			"same, with a whole forged chain in the client's header",
 			"X-Forwarded-For", "203.0.113.9",
 			"X-UR-Forwarded-For", "8.8.8.8:1, 6.6.6.6:2",
+			1,
 		},
 		{
 			"proxy owns X-UR-Forwarded-For (warp load balancer), client sends X-Forwarded-For",
 			"X-UR-Forwarded-For", "203.0.113.9:41001",
 			"X-Forwarded-For", "6.6.6.6",
+			1,
 		},
 		{
 			"proxy appends to X-Forwarded-For, client still tries the other header",
 			"X-Forwarded-For", "10.0.0.1, 203.0.113.9",
 			"X-UR-Forwarded-For", "6.6.6.6:1234",
+			1,
+		},
+
+		// The shapes below are the ones the first pass of the conflict rule
+		// missed. The proxy's header is PRESENT and names only addresses
+		// inside an enumerated CIDR, so it claims no client -- and a candidate
+		// that claims no client used to be skipped as "cannot disagree",
+		// leaving the client's header the only claim and handing the client
+		// the address it wrote. Both orderings are here, because the header a
+		// proxy owns differs by product and only one of the two directions was
+		// guarded.
+		//
+		// They report NOTHING: see TestAHeaderThatNamesNoClientIsNotSteppedOver
+		// for why, and note that a client can reach this shape at will, so a
+		// report here would let it occupy the peer's conflicting-headers
+		// suppression slot and silence a genuine one.
+		{
+			"proxy's X-Forwarded-For names only an enumerated hop, client sends X-UR-Forwarded-For",
+			"X-Forwarded-For", "172.20.5.5",
+			"X-UR-Forwarded-For", "6.6.6.6:1234",
+			0,
+		},
+		{
+			"same, with a chain of two enumerated hops in the proxy's header",
+			"X-Forwarded-For", "172.18.0.9, 172.20.5.5",
+			"X-UR-Forwarded-For", "6.6.6.6:1234",
+			0,
+		},
+		{
+			"mirror: proxy's X-UR-Forwarded-For names only an enumerated hop, client sends X-Forwarded-For",
+			"X-UR-Forwarded-For", "172.20.5.5:41001",
+			"X-Forwarded-For", "6.6.6.6",
+			0,
 		},
 	} {
 		t.Run(shape.what, func(t *testing.T) {
@@ -887,13 +930,17 @@ func TestASecondForwardingHeaderCannotChooseTheBucket(t *testing.T) {
 					got, ingressProxyAddress,
 				)
 			}
-			if len(*reports) != 1 {
+			if len(*reports) != shape.wantReports {
 				t.Fatalf(
 					"a trusted proxy passed a client-supplied forwarding header through and %d "+
-						"reports were emitted, want 1: the clients that reach this path share one "+
-						"rate-limit budget and nothing says so\n%s",
-					len(*reports), strings.Join(*reports, "\n"),
+						"reports were emitted, want %d: either the clients that reach this path "+
+						"share one rate-limit budget and nothing says so, or a client can occupy "+
+						"the peer's suppression slot and silence a genuine report\n%s",
+					len(*reports), shape.wantReports, strings.Join(*reports, "\n"),
 				)
+			}
+			if shape.wantReports == 0 {
+				return
 			}
 			captured := (*reports)[0]
 			for _, want := range []string{
@@ -1444,6 +1491,44 @@ func TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket(t *testing.T
 					"forwarded address again, the right-to-left walk has stopped skipping "+
 					"enumerated hops and a client can prepend its own address",
 				shape.what, got, ingressProxyAddress,
+			)
+		}
+	}
+
+	// The claim above -- "shares the proxy's bucket" -- has to hold when the
+	// caller ALSO sends the other forwarding header, which is the only way it
+	// is worth anything. It did not: a header naming only enumerated hops was
+	// read as making no claim, so it could not contradict the client's header,
+	// and the caller got the address it wrote instead of the proxy's bucket.
+	// That is not "shares the proxy's bucket", it is "escapes rate limiting" --
+	// the opposite of what this test and reportUnenumeratedProxy both promise.
+	//
+	// These are not table rows because legacyTrustedBranch reads ONE header and
+	// the premise above is that the old implementation RESOLVED the shape; a
+	// two-header request has no single old answer to compare against.
+	for _, both := range []struct {
+		what string
+		ur   string
+		xff  string
+	}{
+		{"the caller adds X-UR-Forwarded-For to the proxy's X-Forwarded-For", "6.6.6.6:1234", insideTheRange},
+		{"the caller adds X-Forwarded-For to the proxy's X-UR-Forwarded-For", insideTheRange + ":41001", "6.6.6.6"},
+		{"a whole forged chain alongside the enumerated hop", "8.8.8.8:1, 6.6.6.6:2", insideTheRange},
+	} {
+		got, err := ResolveClientAddress(
+			bothHeadersRequest("X-UR-Forwarded-For", both.ur, "X-Forwarded-For", both.xff),
+			trusted,
+		)
+		if err != nil {
+			t.Fatalf("%s: %v", both.what, err)
+		}
+		if got != ingressProxyAddress {
+			t.Fatalf(
+				"%s: X-UR-Forwarded-For %q + X-Forwarded-For %q resolved to %q, want the "+
+					"peer %s. A caller inside an enumerated range must SHARE the proxy's "+
+					"bucket, which is what this test and the operator report both state; "+
+					"resolving to the other header lets it choose any bucket it likes",
+				both.what, both.ur, both.xff, got, ingressProxyAddress,
 			)
 		}
 	}

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -811,6 +811,48 @@ func TestForwardedSourcePortStillPairsWithBareXForwardedFor(t *testing.T) {
 	}
 }
 
+// TestFourInSixAddressesAreOneAddressEverywhere: a v4-mapped v6 peer
+// ([::ffff:203.0.113.9]) and the same host arriving as plain ipv4 are one host,
+// and every consumer of the resolved address has to agree about that.
+//
+// proxyIsTrusted unmaps; server.ClientIpHashForAddr does NOT -- it branches on
+// addr.Is4(), which is false for the mapped form, and hashes the /56 v6 network
+// instead of the /29 v4 one. So leaving the mapped form in place gives one host
+// two per-address budgets and two report slots, which halves the effective cap
+// on the report set and doubles every rate limit for anyone who can choose
+// which form their peer address takes.
+func TestFourInSixAddressesAreOneAddressEverywhere(t *testing.T) {
+	captureProxyReports(t)
+	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
+	mapped := httptest.NewRequest("POST", "/auth/network-create", nil)
+	mapped.RemoteAddr = "[::ffff:203.0.113.9]:41001"
+	got, err := ResolveClientAddress(mapped, trusted)
+	if err != nil {
+		t.Fatalf("resolve mapped peer: %v", err)
+	}
+	if got != "203.0.113.9:41001" {
+		t.Fatalf(
+			"a v4-mapped peer resolved to %q, want 203.0.113.9:41001: it now buckets "+
+				"under the ipv6 /56 rule instead of the ipv4 /29 one and holds a second, "+
+				"separate rate-limit budget",
+			got,
+		)
+	}
+
+	// the same inside a forwarding header from a trusted peer
+	forwarded := httptest.NewRequest("POST", "/auth/network-create", nil)
+	forwarded.RemoteAddr = "127.0.0.1:52344"
+	forwarded.Header.Set("X-Forwarded-For", "::ffff:203.0.113.9")
+	got, err = ResolveClientAddress(forwarded, trusted)
+	if err != nil {
+		t.Fatalf("resolve mapped forwarded address: %v", err)
+	}
+	if got != "203.0.113.9:0" {
+		t.Fatalf("a v4-mapped forwarded address resolved to %q, want 203.0.113.9:0", got)
+	}
+}
+
 // TestEveryLoosenedShapeUsedToBeAnHttp500 is the argument that this change
 // cannot regress a working deployment, written as a test.
 //

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -602,7 +602,12 @@ func TestUnenumeratedProxyReportNamesTheRemedyAndItsPrecondition(t *testing.T) {
 		// nothing: the client sets one of the others and picks its own bucket.
 		// This report is what recruits operators into enumerating a proxy at
 		// all, so it is where the whole contract has to be stated.
-		"OVERWRITE OR STRIP ALL THREE", "X-UR-Forwarded-For", "X-Forwarded-Source-Port",
+		//
+		// The ENUMERATION is pinned, not the three names on their own: both
+		// reports already mention all three headers incidentally, so asserting
+		// the names alone still passed with the contract sentence gutted.
+		"OVERWRITE OR STRIP ALL THREE",
+		"X-Forwarded-For, X-UR-Forwarded-For and X-Forwarded-Source-Port",
 	} {
 		if !strings.Contains(captured, want) {
 			t.Fatalf(
@@ -891,7 +896,11 @@ func TestASecondForwardingHeaderCannotChooseTheBucket(t *testing.T) {
 				)
 			}
 			captured := (*reports)[0]
-			for _, want := range []string{"X-Forwarded-For", "X-UR-Forwarded-For", "TRUSTED", "172.18.0.7"} {
+			for _, want := range []string{
+				"X-Forwarded-For", "X-UR-Forwarded-For", "TRUSTED", "172.18.0.7",
+				"OVERWRITE OR STRIP ALL THREE",
+				"X-Forwarded-For, X-UR-Forwarded-For and X-Forwarded-Source-Port",
+			} {
 				if !strings.Contains(captured, want) {
 					t.Fatalf(
 						"the conflicting-header report does not mention %q, so an operator cannot "+
@@ -1132,7 +1141,8 @@ func TestUnreadableForwardingHeaderFromATrustedPeerDegradesAndIsReported(t *test
 	// so this report states the same complete header contract as the
 	// unenumerated one -- all three headers, not just the broken one
 	for _, want := range []string{
-		"OVERWRITE OR STRIP ALL THREE", "X-Forwarded-For", "X-UR-Forwarded-For", "X-Forwarded-Source-Port",
+		"OVERWRITE OR STRIP ALL THREE",
+		"X-Forwarded-For, X-UR-Forwarded-For and X-Forwarded-Source-Port",
 	} {
 		if !strings.Contains((*reports)[0], want) {
 			t.Fatalf(

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -1002,6 +1002,58 @@ func TestProxySettingBothForwardingHeadersConsistentlyIsUnchanged(t *testing.T) 
 	}
 }
 
+// TestAnEmptyChainElementIsNotSkipped pins a decision that looks like a bug and
+// is deliberate.
+//
+// A trailing comma -- "203.0.113.9," -- leaves an element that names nobody,
+// and RFC 9110 list syntax says empty elements do not count. Skipping it and
+// reading the entry to its left would turn a peer fallback into a resolved
+// client address, which is friendlier. It is refused because the shape it
+// would rescue is indistinguishable from the shape it would break: where the
+// header is entirely client-supplied (the proxy owns the OTHER one), a client
+// that writes "6.6.6.6," would have chosen its own bucket. Nothing in this
+// deployment's proxy set emits an empty element, so the tolerance buys nothing
+// real and the safe reading is the unreadable one -- peer address, loud report.
+//
+// This is what makes it a decision rather than an oversight: if a proxy that
+// needs it ever turns up, deleting this test is the deliberate act.
+func TestAnEmptyChainElementIsNotSkipped(t *testing.T) {
+	reports := captureProxyReports(t)
+	trusted := trustedIngress()
+
+	got, err := ResolveClientAddress(proxiedRequest("X-Forwarded-For", "203.0.113.9,"), trusted)
+	if err != nil {
+		t.Fatalf("a trailing comma returned an error (%v); router.wrap makes that a 500", err)
+	}
+	if got != ingressProxyAddress {
+		t.Fatalf(
+			"a chain with an empty last element resolved to %q, want the peer address %s. "+
+				"Skipping empty elements also rescues a wholly client-supplied header",
+			got, ingressProxyAddress,
+		)
+	}
+	if len(*reports) != 1 || !strings.Contains((*reports)[0], "could not be read") {
+		t.Fatalf(
+			"an empty chain element must degrade LOUDLY, like any other unreadable "+
+				"header; got %d reports\n%s",
+			len(*reports), strings.Join(*reports, "\n"),
+		)
+	}
+
+	// the shape the decision protects
+	got, err = ResolveClientAddress(proxiedRequest("X-Forwarded-For", "6.6.6.6,"), trusted)
+	if err != nil {
+		t.Fatalf("a client-supplied chain with a trailing comma errored: %v", err)
+	}
+	if ip, _, splitErr := server.SplitClientAddress(got); splitErr == nil && ip == "6.6.6.6" {
+		t.Fatalf(
+			"a client wrote X-Forwarded-For: \"6.6.6.6,\" and the api resolved to %q. The "+
+				"trailing comma was skipped and the client chose its own rate-limit bucket",
+			got,
+		)
+	}
+}
+
 // TestAHeaderThatNamesNoClientIsNotSteppedOver pins which header decides once
 // two are present and only one of them names anybody.
 //

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -8,9 +8,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/urnetwork/server"
 )
 
-// Regression suite for wrongful 429/503 on account creation.
+// Regression suite for wrongful 429/503 on account creation, and for the HTTP
+// 500 the first attempt at fixing it would have caused.
 //
 // Every per-address budget in the service keys off the address
 // ResolveClientAddress returns: the account-creation limit (5 per 24h,
@@ -21,6 +24,17 @@ import (
 // with "429 You have reached the maximum number of account creations for
 // today." or "503 User auth attempts exceeded limits." for something five
 // strangers did.
+//
+// The other half of this file is the opposite failure. The resolver used to
+// require a header shape almost no real proxy sends -- X-Forwarded-For paired
+// with X-Forwarded-Source-Port, single hop -- and returned an ERROR for
+// anything else. router.wrap and router.wrapWithInput both turn a session
+// construction failure into HTTP 500, on every endpoint. So an operator who
+// read the "add its subnet to BRINGYOUR_TRUSTED_PROXY_CIDRS" report, enumerated
+// their stock nginx, and stopped there took the entire api down: nginx sends a
+// bare X-Forwarded-For, and $proxy_add_x_forwarded_for appends a comma on the
+// second hop. Those shapes now resolve; anything still unreadable degrades to
+// the peer address and is reported, never served as a 500.
 
 const (
 	// the ingress proxy's own address on a container bridge network
@@ -36,13 +50,26 @@ func ingressRequest(clientIp string, clientPort string) *http.Request {
 	return req
 }
 
+// proxiedRequest is a request arriving from a trusted proxy carrying whatever
+// header a real proxy would have set, and nothing this service invented.
+func proxiedRequest(header string, value string) *http.Request {
+	req := httptest.NewRequest("POST", "/auth/network-create", nil)
+	req.RemoteAddr = ingressProxyAddress
+	req.Header.Set(header, value)
+	return req
+}
+
+func trustedIngress() []netip.Prefix {
+	return []netip.Prefix{netip.MustParsePrefix(ingressProxyCidr)}
+}
+
 // TestResolveClientAddressSeparatesClientsBehindTrustedIngressProxy is the
 // highest-value assertion in this suite: two unrelated signups arriving through
 // the same proxy must not resolve to the same address. A resolver that returns
 // the proxy address for both gives the entire fleet a single 5-per-24h signup
 // budget.
 func TestResolveClientAddressSeparatesClientsBehindTrustedIngressProxy(t *testing.T) {
-	trusted := []netip.Prefix{netip.MustParsePrefix(ingressProxyCidr)}
+	trusted := trustedIngress()
 
 	first, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted)
 	if err != nil {
@@ -86,9 +113,7 @@ func TestResolveClientAddressSeparatesClientsBehindTrustedIngressProxy(t *testin
 func TestNewClientSessionFromRequestUsesConfiguredTrustedProxies(t *testing.T) {
 	original := trustedProxyPrefixes
 	defer func() { trustedProxyPrefixes = original }()
-	trustedProxyPrefixes = func() []netip.Prefix {
-		return []netip.Prefix{netip.MustParsePrefix(ingressProxyCidr)}
-	}
+	trustedProxyPrefixes = trustedIngress
 
 	firstSession, err := NewClientSessionFromRequest(ingressRequest("203.0.113.9", "41001"))
 	if err != nil {
@@ -140,7 +165,9 @@ func TestNewClientSessionFromRequestUsesConfiguredTrustedProxies(t *testing.T) {
 // still deliberately does not assert the deployment is configured, because it
 // cannot.
 func TestUnenumeratedIngressProxyCollapsesEveryClientOntoOneAddress(t *testing.T) {
-	resetUnenumeratedProxyReports()
+	// capture rather than merely reset, so this test does not print a real
+	// operator alert into the go test output
+	captureProxyReports(t)
 	defaults := trustedProxyPrefixes()
 
 	for _, prefix := range defaults {
@@ -171,30 +198,39 @@ func TestUnenumeratedIngressProxyCollapsesEveryClientOntoOneAddress(t *testing.T
 	}
 }
 
-// capturedProxyReport is one operator-facing report of an unenumerated proxy.
-type capturedProxyReport struct {
-	peer   netip.Addr
-	header string
-}
-
-// captureProxyReports swaps the reporter for the duration of a test and clears
-// the suppression state on both sides, so one test cannot silence the next.
-func captureProxyReports(t *testing.T) *[]capturedProxyReport {
+// captureProxyReports collects the operator reports a test provokes.
+//
+// It swaps glogErrorf -- the LAST seam before the log -- and nothing else. An
+// earlier version of this helper replaced reportUnenumeratedProxy with a stub
+// that re-implemented the rate-limit guard, which meant every test that counted
+// reports was counting the stub: the production guard could be deleted outright
+// and the whole suite stayed green. Stubbing here puts ResolveClientAddress ->
+// the real report function -> the real shouldReportProxy -> the log under one
+// seam, so the counts below are counts of what the service would actually
+// print.
+func captureProxyReports(t *testing.T) *[]string {
 	t.Helper()
-	reports := []capturedProxyReport{}
-	original := reportUnenumeratedProxy
-	resetUnenumeratedProxyReports()
-	reportUnenumeratedProxy = func(peer netip.Addr, header string, trusted []netip.Prefix) {
-		if !shouldReportUnenumeratedProxy(peer, time.Now()) {
-			return
-		}
-		reports = append(reports, capturedProxyReport{peer: peer, header: header})
+	reports := []string{}
+	original := glogErrorf
+	resetProxyReports()
+	glogErrorf = func(format string, args ...any) {
+		reports = append(reports, fmt.Sprintf(format, args...))
 	}
 	t.Cleanup(func() {
-		reportUnenumeratedProxy = original
-		resetUnenumeratedProxyReports()
+		glogErrorf = original
+		resetProxyReports()
 	})
 	return &reports
+}
+
+func reportsMentioning(reports []string, substring string) int {
+	count := 0
+	for _, report := range reports {
+		if strings.Contains(report, substring) {
+			count += 1
+		}
+	}
+	return count
 }
 
 // TestUnenumeratedIngressProxyIsReportedLoudly is the test for the highest-value
@@ -225,11 +261,11 @@ func TestUnenumeratedIngressProxyIsReportedLoudly(t *testing.T) {
 			len(*reports),
 		)
 	}
-	if got := (*reports)[0].peer.String(); got != "172.18.0.7" {
-		t.Fatalf("report named peer %q, want the actual TCP peer 172.18.0.7", got)
+	if !strings.Contains((*reports)[0], "172.18.0.7") {
+		t.Fatalf("report does not name the actual TCP peer 172.18.0.7\nreport: %s", (*reports)[0])
 	}
-	if (*reports)[0].header != "X-Forwarded-For" {
-		t.Fatalf("report named header %q, want X-Forwarded-For", (*reports)[0].header)
+	if !strings.Contains((*reports)[0], "X-Forwarded-For") {
+		t.Fatalf("report does not name the header that triggered it\nreport: %s", (*reports)[0])
 	}
 
 	// X-UR-Forwarded-For is the other header a trusted peer is allowed to set,
@@ -243,8 +279,8 @@ func TestUnenumeratedIngressProxyIsReportedLoudly(t *testing.T) {
 	if len(*reports) != 2 {
 		t.Fatalf("X-UR-Forwarded-For from an untrusted peer produced %d reports total, want 2", len(*reports))
 	}
-	if (*reports)[1].header != "X-UR-Forwarded-For" {
-		t.Fatalf("second report named header %q, want X-UR-Forwarded-For", (*reports)[1].header)
+	if !strings.Contains((*reports)[1], "X-UR-Forwarded-For") {
+		t.Fatalf("second report does not name X-UR-Forwarded-For\nreport: %s", (*reports)[1])
 	}
 }
 
@@ -273,8 +309,12 @@ func TestUnenumeratedProxyReportDoesNotTrustThePeer(t *testing.T) {
 
 // TestUnenumeratedProxyReportIsRateLimited: the report is emitted on a request
 // path, so an unbounded one is a log-flooding hole -- any client can set
-// X-Forwarded-For on a directly reachable api. Once per distinct peer, then no
-// more than once per interval.
+// X-Forwarded-For on a directly reachable api. Once per distinct peer per
+// interval.
+//
+// This drives the production guard, not a copy of it: captureProxyReports swaps
+// only glogErrorf, so deleting the shouldReportProxy call from
+// reportUnenumeratedProxy fails here.
 func TestUnenumeratedProxyReportIsRateLimited(t *testing.T) {
 	reports := captureProxyReports(t)
 	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
@@ -307,45 +347,124 @@ func TestUnenumeratedProxyReportIsRateLimited(t *testing.T) {
 			len(*reports),
 		)
 	}
+	if reportsMentioning(*reports, "172.18.0.8") != 1 {
+		t.Fatalf("the second peer was not named in any report:\n%s", strings.Join(*reports, "\n"))
+	}
 }
 
-// TestUnenumeratedProxyReportSurvivesTheBoundedPeerSet pins the suppression
-// state directly. The per-peer set is bounded, so a caller cycling source
-// addresses cannot grow it without limit -- but once it is full the report must
-// keep firing on the interval, otherwise a deployment that becomes wedged later
-// goes quiet again, which is the exact failure this change exists to prevent.
-func TestUnenumeratedProxyReportSurvivesTheBoundedPeerSet(t *testing.T) {
+// TestProxyReportSuppressionIsPerPeerAndPerCondition pins the suppression state
+// directly.
+//
+// It used to be one global "last reported at" instant shared by every peer:
+// with the peer set full, whoever called first in each interval took the only
+// token, so a caller who could reach the api directly and out-pace the real
+// proxy kept the operator's log full of their own address while the genuinely
+// wedged proxy was named rarely or never. Per-peer timestamps remove that.
+//
+// The set is still bounded -- a caller cycling source addresses must not grow
+// server memory without limit -- but entries are now pruned once they age out,
+// so filling it is no longer permanent for the process lifetime.
+func TestProxyReportSuppressionIsPerPeerAndPerCondition(t *testing.T) {
 	captureProxyReports(t)
 
 	peer := netip.MustParseAddr("172.18.0.7")
+	unenumerated := proxyReportKey{peer: peer, kind: proxyReportUnenumerated}
+	unusable := proxyReportKey{peer: peer, kind: proxyReportUnusableHeader}
 	now := time.Now()
-	if !shouldReportUnenumeratedProxy(peer, now) {
+
+	if !shouldReportProxy(unenumerated, now) {
 		t.Fatal("the first sighting of a peer was suppressed")
 	}
-	if shouldReportUnenumeratedProxy(peer, now.Add(unenumeratedProxyReportInterval-time.Second)) {
+	if shouldReportProxy(unenumerated, now.Add(proxyReportInterval-time.Second)) {
 		t.Fatal("a repeat inside the interval was reported; the report can be flooded")
 	}
-	if !shouldReportUnenumeratedProxy(peer, now.Add(unenumeratedProxyReportInterval)) {
+	if !shouldReportProxy(unusable, now.Add(time.Second)) {
+		t.Fatal(
+			"one condition suppressed a different condition for the same peer; the two " +
+				"have different remedies and an operator needs to see both",
+		)
+	}
+	if !shouldReportProxy(unenumerated, now.Add(proxyReportInterval)) {
 		t.Fatal("no report after the interval elapsed; a wedged deployment goes silent")
 	}
 
-	// fill the bounded set, then confirm the interval path still fires
-	resetUnenumeratedProxyReports()
-	for i := 0; i < unenumeratedProxyReportedMax+16; i += 1 {
-		shouldReportUnenumeratedProxy(netip.AddrFrom4([4]byte{10, byte(i >> 8), byte(i), 1}), now)
+	// a busy stranger must not take the wedged proxy's slot
+	resetProxyReports()
+	stranger := netip.MustParseAddr("198.51.100.1")
+	strangerKey := proxyReportKey{peer: stranger, kind: proxyReportUnenumerated}
+	for i := 0; i < 100; i += 1 {
+		shouldReportProxy(strangerKey, now.Add(time.Duration(i)*time.Millisecond))
 	}
-	unenumeratedProxyMutex.Lock()
-	size := len(unenumeratedProxyReported)
-	unenumeratedProxyMutex.Unlock()
-	if unenumeratedProxyReportedMax < size {
+	if !shouldReportProxy(unenumerated, now) {
+		t.Fatal(
+			"a peer that had never been reported was suppressed by another peer's " +
+				"traffic: whoever calls first holds the only token and the real wedged " +
+				"proxy is never named",
+		)
+	}
+
+	// a 4-in-6 form of a peer is the same peer: two map slots for one host
+	// halves the effective cap, and proxyIsTrusted already unmaps
+	resetProxyReports()
+	if !shouldReportProxy(proxyReportKey{peer: netip.MustParseAddr("203.0.113.9"), kind: proxyReportUnenumerated}, now) {
+		t.Fatal("first sighting suppressed")
+	}
+	if shouldReportProxy(proxyReportKey{peer: netip.MustParseAddr("::ffff:203.0.113.9"), kind: proxyReportUnenumerated}, now) {
+		t.Fatal("the 4-in-6 form of an already-reported peer took a second slot")
+	}
+}
+
+// TestProxyReportSetIsBoundedAndPrunes: the suppression map is written only
+// when a report is actually emitted and pruned when it fills, so a caller
+// cycling source addresses can neither grow it without limit nor silence it
+// permanently. The second half is the one that matters -- the previous version
+// never evicted, so once 1024 peers had been seen the per-peer path was gone
+// for the lifetime of the process.
+func TestProxyReportSetIsBoundedAndPrunes(t *testing.T) {
+	captureProxyReports(t)
+	now := time.Now()
+
+	for i := 0; i < proxyReportedMax+512; i += 1 {
+		key := proxyReportKey{
+			peer: netip.AddrFrom4([4]byte{10, byte(i >> 8), byte(i), 1}),
+			kind: proxyReportUnenumerated,
+		}
+		shouldReportProxy(key, now)
+	}
+	proxyReportMutex.Lock()
+	size := len(proxyReportedAt)
+	proxyReportMutex.Unlock()
+	if proxyReportedMax < size {
 		t.Fatalf(
 			"the per-peer suppression set grew to %d entries, cap is %d: a caller "+
 				"cycling source addresses can grow server memory without limit",
-			size, unenumeratedProxyReportedMax,
+			size, proxyReportedMax,
 		)
 	}
-	if !shouldReportUnenumeratedProxy(netip.MustParseAddr("198.51.100.1"), now.Add(unenumeratedProxyReportInterval)) {
-		t.Fatal("with the peer set full, the interval path stopped reporting entirely")
+
+	// with the set full of entries still inside the interval, the report must
+	// not stop entirely
+	fresh := proxyReportKey{peer: netip.MustParseAddr("198.51.100.1"), kind: proxyReportUnenumerated}
+	if !shouldReportProxy(fresh, now.Add(proxyReportInterval)) {
+		t.Fatal("with the peer set full, the report stopped entirely")
+	}
+
+	// once the old entries age out they are pruned, so the set does not stay
+	// full forever and per-peer reporting comes back
+	later := now.Add(2 * proxyReportInterval)
+	if !shouldReportProxy(proxyReportKey{peer: netip.MustParseAddr("198.51.100.2"), kind: proxyReportUnenumerated}, later) {
+		t.Fatal("a new peer after the interval was suppressed")
+	}
+	proxyReportMutex.Lock()
+	prunedSize := len(proxyReportedAt)
+	proxyReportMutex.Unlock()
+	if proxyReportedMax <= prunedSize {
+		t.Fatalf(
+			"the suppression set was still full (%d entries) an interval after every "+
+				"entry aged out: it never evicts, so a burst of distinct peers disables "+
+				"per-peer reporting for the lifetime of the process",
+			prunedSize,
+		)
 	}
 }
 
@@ -370,33 +489,388 @@ func TestNoProxyReportWithoutForwardingHeaders(t *testing.T) {
 	}
 }
 
-// TestUnenumeratedProxyReportNamesTheEnvironmentVariable pins the operator's
-// only actionable detail. A report that says something is wrong without naming
-// the peer and the variable to set is not the fix -- the deployment sat wedged
-// because nobody knew which knob to turn.
-func TestUnenumeratedProxyReportNamesTheEnvironmentVariable(t *testing.T) {
-	resetUnenumeratedProxyReports()
-	defer resetUnenumeratedProxyReports()
-
-	captured := ""
-	original := glogErrorf
-	glogErrorf = func(format string, args ...any) {
-		captured = fmt.Sprintf(format, args...)
-	}
-	defer func() { glogErrorf = original }()
+// TestUnenumeratedProxyReportNamesTheRemedyAndItsPrecondition pins the
+// operator's only actionable detail, and the correction that motivated this
+// round of review.
+//
+// The report tells an operator to add the peer's subnet to
+// BRINGYOUR_TRUSTED_PROXY_CIDRS. The trusted branch used to demand
+// X-Forwarded-For paired with X-Forwarded-Source-Port and single-hop, and to
+// return an error -- HTTP 500 on every endpoint -- for anything else. Stock
+// nginx sends neither the port header nor a single-hop chain. Following this
+// message was therefore a way to take the api down. The header contract is now
+// permissive enough for a real proxy, and the message states it, including the
+// one thing an operator can still get wrong: a proxy that passes a
+// client-supplied forwarding header through unchanged lets the client choose
+// its own rate-limit bucket.
+func TestUnenumeratedProxyReportNamesTheRemedyAndItsPrecondition(t *testing.T) {
+	reports := captureProxyReports(t)
 
 	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
 	if _, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted); err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
+	if len(*reports) != 1 {
+		t.Fatalf("want exactly one report, got %d", len(*reports))
+	}
+	captured := (*reports)[0]
 
-	for _, want := range []string{"172.18.0.7", trustedProxyCidrsEnvironment, "X-Forwarded-For", "127.0.0.0/8"} {
+	for _, want := range []string{
+		// which peer, which knob, what is trusted today
+		"172.18.0.7", trustedProxyCidrsEnvironment, "X-Forwarded-For", "127.0.0.0/8",
+		// and what the proxy must actually do once it is trusted, so the
+		// operator cannot follow this into a different outage or into a
+		// spoofable configuration
+		"$proxy_add_x_forwarded_for", "last entry", "unchanged",
+	} {
 		if !strings.Contains(captured, want) {
 			t.Fatalf(
 				"the misconfiguration report does not mention %q; an operator reading it "+
-					"cannot tell which peer to enumerate or where.\nreport: %s",
+					"cannot tell which peer to enumerate, where, or what that proxy has to "+
+					"send once it is trusted.\nreport: %s",
 				want, captured,
 			)
+		}
+	}
+}
+
+// -- the trusted branch: what real proxies actually send -----------------------
+
+// TestStockNginxBareXForwardedForResolvesTheClient is the direct regression for
+// the defect this round exists to fix.
+//
+// nginx's documented recipe is
+//
+//	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+//
+// and it sends no X-Forwarded-Source-Port at all; ALB, CloudFront and
+// Cloudflare are the same. The trusted branch used to answer that with
+// `forwarded source requires one IP and one port`, which router.wrap and
+// router.wrapWithInput turn into HTTP 500 for EVERY endpoint. An operator who
+// followed the report above and enumerated their nginx took the whole api down.
+//
+// Two assertions, because either one alone is satisfiable by a wrong fix:
+// resolving without error (not a 500) AND resolving to the client rather than
+// the proxy (not a fleet-wide budget).
+func TestStockNginxBareXForwardedForResolvesTheClient(t *testing.T) {
+	captureProxyReports(t)
+	trusted := trustedIngress()
+
+	got, err := ResolveClientAddress(proxiedRequest("X-Forwarded-For", "203.0.113.9"), trusted)
+	if err != nil {
+		t.Fatalf(
+			"a trusted proxy sending only a bare X-Forwarded-For -- stock nginx, ALB, "+
+				"CloudFront, Cloudflare -- was answered with an error: %v. "+
+				"router.wrap and router.wrapWithInput turn that into HTTP 500 on every "+
+				"endpoint, so enumerating that proxy takes the api down",
+			err,
+		)
+	}
+	ip, port, err := server.SplitClientAddress(got)
+	if err != nil {
+		t.Fatalf("resolved address %q does not split: %v", got, err)
+	}
+	if ip != "203.0.113.9" {
+		t.Fatalf(
+			"a bare X-Forwarded-For from a trusted proxy resolved to ip %q (%q); every "+
+				"client behind that proxy shares one rate-limit budget",
+			ip, got,
+		)
+	}
+	// the port is genuinely unknown here -- no proxy in this shape sends one --
+	// and 0 is how that is spelled. Every limiter that matters buckets on the
+	// ip alone (server.ClientIpHash), so this costs nothing.
+	if port != 0 {
+		t.Fatalf("resolved %q, want port 0 for an address with no forwarded port", got)
+	}
+
+	// second hop: $proxy_add_x_forwarded_for APPENDS, so a two-proxy path
+	// produces a comma. That was the other 500.
+	got, err = ResolveClientAddress(
+		proxiedRequest("X-Forwarded-For", "203.0.113.9, 172.18.0.9"),
+		trusted,
+	)
+	if err != nil {
+		t.Fatalf("a two-hop X-Forwarded-For chain was answered with an error: %v", err)
+	}
+	if ip, _, _ := server.SplitClientAddress(got); ip != "203.0.113.9" {
+		t.Fatalf(
+			"a chain whose later hops are all enumerated proxies resolved to %q, want "+
+				"the client 203.0.113.9: the trusted hops must be walked past, not "+
+				"treated as the client",
+			got,
+		)
+	}
+}
+
+// TestClientCannotForgeItsAddressThroughATrustedProxy is the safety half of the
+// change above, and the reason the chain is walked from the RIGHT.
+//
+// X-Forwarded-For is a client-supplied header. A proxy that uses
+// $proxy_add_x_forwarded_for appends what it observed, so a client that sends
+// "X-Forwarded-For: 6.6.6.6" causes the api to see "6.6.6.6, <client ip>". Read
+// left to right -- "the original client" -- every client behind the proxy picks
+// its own rate-limit bucket and walks out of every per-address limit in the
+// service, which is strictly worse than the shared-budget bug being fixed.
+func TestClientCannotForgeItsAddressThroughATrustedProxy(t *testing.T) {
+	captureProxyReports(t)
+	trusted := trustedIngress()
+
+	forged := "6.6.6.6"
+	real := "203.0.113.9"
+
+	for _, chain := range []string{
+		// client prepended one address
+		forged + ", " + real,
+		// client prepended a whole fake chain
+		forged + ", 8.8.8.8, 9.9.9.9, " + real,
+		// client prepended something that is not an address at all
+		"not-an-address, " + real,
+		// client prepended an address inside the trusted range, trying to make
+		// the walk skip past its real address
+		"6.6.6.6, 172.18.0.9, " + real,
+	} {
+		got, err := ResolveClientAddress(proxiedRequest("X-Forwarded-For", chain), trusted)
+		if err != nil {
+			t.Fatalf("chain %q: %v", chain, err)
+		}
+		ip, _, err := server.SplitClientAddress(got)
+		if err != nil {
+			t.Fatalf("chain %q resolved to %q which does not split: %v", chain, got, err)
+		}
+		if ip == forged {
+			t.Fatalf(
+				"a client behind a trusted proxy set X-Forwarded-For: %q and was "+
+					"attributed to %q. It just chose its own rate-limit bucket and stepped "+
+					"outside every per-address limit in the service",
+				chain, ip,
+			)
+		}
+		if ip != real {
+			t.Fatalf("chain %q resolved to %q, want the address the proxy appended, %s", chain, ip, real)
+		}
+	}
+
+	// repeated field lines are equivalent to one comma-joined line (RFC 9110).
+	// A proxy that appends a SECOND X-Forwarded-For line rather than extending
+	// the first is legal, and reading only the first line would hand back
+	// exactly the value the client sent.
+	multiLine := httptest.NewRequest("POST", "/auth/network-create", nil)
+	multiLine.RemoteAddr = ingressProxyAddress
+	multiLine.Header.Add("X-Forwarded-For", forged)
+	multiLine.Header.Add("X-Forwarded-For", real)
+	got, err := ResolveClientAddress(multiLine, trusted)
+	if err != nil {
+		t.Fatalf("repeated X-Forwarded-For lines: %v", err)
+	}
+	if ip, _, _ := server.SplitClientAddress(got); ip != real {
+		t.Fatalf(
+			"a client sent its own X-Forwarded-For line and the proxy appended a second "+
+				"line; the api resolved to %q, want %s. Only the first field line was "+
+				"read, so the client chose its own bucket",
+			ip, real,
+		)
+	}
+}
+
+// TestUrForwardedForChainIsNotReadAsASingleHop: the same right-to-left rule
+// applies to this service's own header. It used to be rejected outright, which
+// is safe but is a 500; taking the FIRST element instead would be the forgery
+// above wearing a different header name.
+func TestUrForwardedForChainIsNotReadAsASingleHop(t *testing.T) {
+	captureProxyReports(t)
+	trusted := trustedIngress()
+
+	got, err := ResolveClientAddress(
+		proxiedRequest("X-UR-Forwarded-For", "6.6.6.6:1, 203.0.113.9:41001"),
+		trusted,
+	)
+	if err != nil {
+		t.Fatalf("X-UR-Forwarded-For chain: %v", err)
+	}
+	if got != "203.0.113.9:41001" {
+		t.Fatalf(
+			"an X-UR-Forwarded-For chain resolved to %q, want 203.0.113.9:41001: the "+
+				"leftmost element is whatever the client supplied",
+			got,
+		)
+	}
+
+	// X-UR-Forwarded-For still wins over X-Forwarded-For when both are present
+	both := httptest.NewRequest("POST", "/auth/network-create", nil)
+	both.RemoteAddr = ingressProxyAddress
+	both.Header.Set("X-UR-Forwarded-For", "203.0.113.9:41001")
+	both.Header.Set("X-Forwarded-For", "198.51.100.20")
+	got, err = ResolveClientAddress(both, trusted)
+	if err != nil {
+		t.Fatalf("both headers: %v", err)
+	}
+	if got != "203.0.113.9:41001" {
+		t.Fatalf("with both headers set the resolver returned %q, want the X-UR-Forwarded-For value", got)
+	}
+}
+
+// TestUnreadableForwardingHeaderFromATrustedPeerDegradesAndIsReported is what
+// keeps the change above honest.
+//
+// Falling back to the peer address instead of erroring cannot produce a wrong
+// attribution -- the peer is where the packets came from, the most restrictive
+// answer available -- but it silently reinstates the fleet-wide-budget collapse
+// this whole file exists to prevent. So it is not silent: a trusted peer whose
+// header cannot be read is named, with its own remedy, distinct from the
+// unenumerated-proxy remedy.
+func TestUnreadableForwardingHeaderFromATrustedPeerDegradesAndIsReported(t *testing.T) {
+	reports := captureProxyReports(t)
+	trusted := trustedIngress()
+
+	got, err := ResolveClientAddress(proxiedRequest("X-Forwarded-For", "not-an-address"), trusted)
+	if err != nil {
+		t.Fatalf(
+			"an unreadable forwarding header from a trusted peer returned an error (%v); "+
+				"router.wrap turns that into HTTP 500 on every endpoint",
+			err,
+		)
+	}
+	if got != ingressProxyAddress {
+		t.Fatalf(
+			"an unreadable header resolved to %q; the only safe fallback is the peer "+
+				"address %s",
+			got, ingressProxyAddress,
+		)
+	}
+	if len(*reports) != 1 {
+		t.Fatalf(
+			"a trusted proxy sent a header this service cannot read and %d reports were "+
+				"emitted, want 1: every client behind it now shares one rate-limit budget "+
+				"and nothing says so",
+			len(*reports),
+		)
+	}
+	if !strings.Contains((*reports)[0], "TRUSTED") || !strings.Contains((*reports)[0], "172.18.0.7") {
+		t.Fatalf(
+			"the report does not identify the trusted peer whose header is broken\nreport: %s",
+			(*reports)[0],
+		)
+	}
+	// the header VALUE is attacker-influenced on any proxy that forwards client
+	// headers, so it must never reach the log
+	if strings.Contains((*reports)[0], "not-an-address") {
+		t.Fatalf(
+			"the report echoed the attacker-supplied header value; log injection\nreport: %s",
+			(*reports)[0],
+		)
+	}
+}
+
+// TestForwardedSourcePortStillPairsWithBareXForwardedFor pins the one shape
+// that already worked, byte for byte. Loosening the contract must not change
+// what the warp sidecar's existing pairing resolves to.
+func TestForwardedSourcePortStillPairsWithBareXForwardedFor(t *testing.T) {
+	captureProxyReports(t)
+	trusted := trustedIngress()
+
+	got, err := ResolveClientAddress(ingressRequest("203.0.113.9", "41001"), trusted)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != "203.0.113.9:41001" {
+		t.Fatalf("X-Forwarded-For + X-Forwarded-Source-Port resolved to %q, want 203.0.113.9:41001", got)
+	}
+
+	// ipv6 through the same pairing
+	v6 := httptest.NewRequest("POST", "/auth/network-create", nil)
+	v6.RemoteAddr = ingressProxyAddress
+	v6.Header.Set("X-Forwarded-For", "2001:db8::7")
+	v6.Header.Set("X-Forwarded-Source-Port", "41001")
+	got, err = ResolveClientAddress(v6, trusted)
+	if err != nil {
+		t.Fatalf("ipv6 resolve: %v", err)
+	}
+	if got != "[2001:db8::7]:41001" {
+		t.Fatalf("ipv6 X-Forwarded-For resolved to %q, want [2001:db8::7]:41001", got)
+	}
+
+	// on a chain the port belongs to whichever hop wrote it and there is no way
+	// to tell which, so it is dropped rather than guessed -- but the ADDRESS is
+	// still resolved, because dropping the port must not cost the client its
+	// own bucket
+	chained := httptest.NewRequest("POST", "/auth/network-create", nil)
+	chained.RemoteAddr = ingressProxyAddress
+	chained.Header.Set("X-Forwarded-For", "6.6.6.6, 203.0.113.9")
+	chained.Header.Set("X-Forwarded-Source-Port", "41001")
+	got, err = ResolveClientAddress(chained, trusted)
+	if err != nil {
+		t.Fatalf("chained resolve: %v", err)
+	}
+	if got != "203.0.113.9:0" {
+		t.Fatalf(
+			"a multi-hop chain took the source port header anyway and resolved to %q, "+
+				"want 203.0.113.9:0",
+			got,
+		)
+	}
+}
+
+// TestEveryLoosenedShapeUsedToBeAnHttp500 is the argument that this change
+// cannot regress a working deployment, written as a test.
+//
+// Each input below is a shape the trusted branch now accepts. On the previous
+// implementation every one of them returned an error, and router.wrap /
+// router.wrapWithInput turn that into HTTP 500. A deployment that reaches any
+// of these paths today is a deployment whose api answers 500 to every request,
+// so there is no working behaviour for the looser contract to take away -- only
+// an outage for it to end.
+func TestEveryLoosenedShapeUsedToBeAnHttp500(t *testing.T) {
+	captureProxyReports(t)
+	trusted := trustedIngress()
+
+	// the previous implementation, verbatim, so the claim is checked rather
+	// than asserted in a comment
+	oldResolve := func(req *http.Request) error {
+		forwarded := strings.TrimSpace(req.Header.Get("X-UR-Forwarded-For"))
+		if forwarded != "" {
+			if strings.Contains(forwarded, ",") {
+				return fmt.Errorf("invalid X-UR-Forwarded-For chain")
+			}
+			if _, err := parseRequestAddress(forwarded); err != nil {
+				return fmt.Errorf("invalid X-UR-Forwarded-For: %w", err)
+			}
+			return nil
+		}
+		forwardedIp := strings.TrimSpace(req.Header.Get("X-Forwarded-For"))
+		forwardedPort := strings.TrimSpace(req.Header.Get("X-Forwarded-Source-Port"))
+		if forwardedIp == "" && forwardedPort == "" {
+			return nil
+		}
+		if forwardedIp == "" || forwardedPort == "" || strings.Contains(forwardedIp, ",") {
+			return fmt.Errorf("forwarded source requires one IP and one port")
+		}
+		return nil
+	}
+
+	for _, shape := range []struct {
+		what   string
+		header string
+		value  string
+	}{
+		{"stock nginx / ALB / CloudFront / Cloudflare", "X-Forwarded-For", "203.0.113.9"},
+		{"two nginx hops ($proxy_add_x_forwarded_for appends)", "X-Forwarded-For", "203.0.113.9, 172.18.0.9"},
+		{"a client that prepended its own value", "X-Forwarded-For", "6.6.6.6, 203.0.113.9"},
+		{"a proxy that writes ip:port into X-Forwarded-For", "X-Forwarded-For", "203.0.113.9:41001"},
+		{"an X-UR-Forwarded-For chain", "X-UR-Forwarded-For", "6.6.6.6:1, 203.0.113.9:41001"},
+		{"an unreadable header from a trusted proxy", "X-Forwarded-For", "not-an-address"},
+	} {
+		req := proxiedRequest(shape.header, shape.value)
+		if err := oldResolve(req); err == nil {
+			t.Fatalf(
+				"%s (%s: %s) did NOT error on the previous implementation, so this test "+
+					"is no longer evidence that the looser contract only replaces 500s -- "+
+					"re-derive the argument",
+				shape.what, shape.header, shape.value,
+			)
+		}
+		if _, err := ResolveClientAddress(req, trusted); err != nil {
+			t.Fatalf("%s (%s: %s) still errors: %v", shape.what, shape.header, shape.value, err)
 		}
 	}
 }

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -333,7 +333,15 @@ func TestUnenumeratedProxyReportIsRateLimited(t *testing.T) {
 		)
 	}
 
-	// a genuinely different peer is worth naming once
+	// A genuinely different peer is worth naming once.
+	//
+	// The spacing here is LOAD-BEARING: the suppression key is a peer network,
+	// not an address (proxyReportPeerBucket), and 172.18.0.7 is the last
+	// address of 172.18.0.0/29 while 172.18.0.8 is the first of 172.18.0.8/29.
+	// Move either one and this stops asserting distinctness -- it becomes one
+	// peer reported twice, which the interval already forbids, and the test
+	// passes for the wrong reason. The invariant itself is pinned on purpose in
+	// TestReportSlotsAreNotBoughtByRotatingSourceAddresses.
 	other := httptest.NewRequest("POST", "/auth/network-create", nil)
 	other.RemoteAddr = "172.18.0.8:52345"
 	other.Header.Set("X-Forwarded-For", "203.0.113.9")

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -468,6 +468,61 @@ func TestProxyReportSetIsBoundedAndPrunes(t *testing.T) {
 	}
 }
 
+// TestProxyReportPruneScanStaysAmortized.
+//
+// The prune walks the whole suppression map, under the process-global mutex,
+// on a code path any caller who can reach the api directly can trigger. Running
+// it on every request while the map is full would hand exactly the caller who
+// filled it an O(cap) critical section per request -- a contention amplifier
+// built out of the flood guard.
+//
+// An entry only becomes prunable after a whole interval, so scanning more often
+// than once per interval cannot free anything the previous scan did not.
+func TestProxyReportPruneScanStaysAmortized(t *testing.T) {
+	captureProxyReports(t)
+	now := time.Now()
+
+	for i := 0; i < proxyReportedMax; i += 1 {
+		shouldReportProxy(proxyReportKey{
+			peer: netip.AddrFrom4([4]byte{10, byte(i >> 8), byte(i), 1}),
+			kind: proxyReportUnenumerated,
+		}, now)
+	}
+	proxyReportMutex.Lock()
+	before := proxyReportPruneScans
+	proxyReportMutex.Unlock()
+
+	// every one of these finds the map full and is refused; none of them can
+	// free a slot, because nothing in it has aged out yet
+	for i := 0; i < 200; i += 1 {
+		shouldReportProxy(proxyReportKey{
+			peer: netip.AddrFrom4([4]byte{198, 51, 100, byte(i)}),
+			kind: proxyReportUnenumerated,
+		}, now)
+	}
+	proxyReportMutex.Lock()
+	after := proxyReportPruneScans
+	proxyReportMutex.Unlock()
+
+	if 1 < after-before {
+		t.Fatalf(
+			"200 requests against a full suppression map ran %d prune scans, want at "+
+				"most 1. Each scan walks %d entries holding the process-global report "+
+				"mutex, on a path any caller can trigger",
+			after-before, proxyReportedMax,
+		)
+	}
+
+	// and once the entries have aged out, a scan does run again and does free
+	// the slots -- an amortized guard that never re-arms is just a leak
+	if !shouldReportProxy(proxyReportKey{
+		peer: netip.MustParseAddr("203.0.113.9"),
+		kind: proxyReportUnenumerated,
+	}, now.Add(2*proxyReportInterval)) {
+		t.Fatal("after every entry aged out, a new peer was still refused a report")
+	}
+}
+
 // TestNoProxyReportWithoutForwardingHeaders: a direct client that sends no
 // forwarding header is the ordinary case for a service reachable without a
 // proxy. Reporting it would bury the real signal.
@@ -759,6 +814,53 @@ func TestUnreadableForwardingHeaderFromATrustedPeerDegradesAndIsReported(t *test
 			"the report echoed the attacker-supplied header value; log injection\nreport: %s",
 			(*reports)[0],
 		)
+	}
+}
+
+// TestChainOfOnlyTrustedHopsResolvesToThePeerWithoutAReport covers the branch
+// where the walk finds no client at all.
+//
+// Ordinary internal traffic looks like this: one of the deployment's own
+// components calls the api through the ingress proxy, so every entry in the
+// chain is an enumerated proxy. There is no client to attribute it to, the peer
+// address is the correct answer, and nothing is misconfigured -- so this must
+// NOT be reported. It shares a return with the unreadable-header case, and if
+// the two are ever conflated the log fills up with alerts about traffic that is
+// working exactly as intended, which buries the report that matters.
+func TestChainOfOnlyTrustedHopsResolvesToThePeerWithoutAReport(t *testing.T) {
+	reports := captureProxyReports(t)
+	trusted := trustedIngress()
+
+	got, err := ResolveClientAddress(proxiedRequest("X-Forwarded-For", "172.18.0.9"), trusted)
+	if err != nil {
+		t.Fatalf("a chain of only trusted hops errored: %v", err)
+	}
+	if got != ingressProxyAddress {
+		t.Fatalf(
+			"a chain whose every entry is an enumerated proxy resolved to %q, want the "+
+				"peer address %s",
+			got, ingressProxyAddress,
+		)
+	}
+	if len(*reports) != 0 {
+		t.Fatalf(
+			"ordinary internal traffic between two enumerated proxies emitted %d "+
+				"misconfiguration reports; nothing is misconfigured, and this buries the "+
+				"report that matters:\n%s",
+			len(*reports), strings.Join(*reports, "\n"),
+		)
+	}
+
+	// same for a longer all-trusted chain
+	got, err = ResolveClientAddress(proxiedRequest("X-Forwarded-For", "172.18.0.9, 172.18.0.10"), trusted)
+	if err != nil {
+		t.Fatalf("a longer all-trusted chain errored: %v", err)
+	}
+	if got != ingressProxyAddress {
+		t.Fatalf("a longer all-trusted chain resolved to %q, want %s", got, ingressProxyAddress)
+	}
+	if len(*reports) != 0 {
+		t.Fatalf("a longer all-trusted chain emitted %d reports", len(*reports))
 	}
 }
 

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -371,6 +371,7 @@ func TestProxyReportSuppressionIsPerPeerAndPerCondition(t *testing.T) {
 	peer := netip.MustParseAddr("172.18.0.7")
 	unenumerated := proxyReportKey{peer: peer, kind: proxyReportUnenumerated}
 	unusable := proxyReportKey{peer: peer, kind: proxyReportUnusableHeader}
+	conflicting := proxyReportKey{peer: peer, kind: proxyReportConflictingHeaders}
 	now := time.Now()
 
 	if !shouldReportProxy(unenumerated, now) {
@@ -384,6 +385,17 @@ func TestProxyReportSuppressionIsPerPeerAndPerCondition(t *testing.T) {
 			"one condition suppressed a different condition for the same peer; the two " +
 				"have different remedies and an operator needs to see both",
 		)
+	}
+	if !shouldReportProxy(conflicting, now.Add(2*time.Second)) {
+		t.Fatal(
+			"a third condition was suppressed by the first two for the same peer. " +
+				"Conflicting forwarding headers mean the proxy is passing a client header " +
+				"through, which is a different edit from either enumerating a subnet or " +
+				"fixing a broken header value",
+		)
+	}
+	if shouldReportProxy(conflicting, now.Add(3*time.Second)) {
+		t.Fatal("a repeat of the conflicting-header condition inside the interval was reported; it can be flooded")
 	}
 	if !shouldReportProxy(unenumerated, now.Add(proxyReportInterval)) {
 		t.Fatal("no report after the interval elapsed; a wedged deployment goes silent")
@@ -583,6 +595,14 @@ func TestUnenumeratedProxyReportNamesTheRemedyAndItsPrecondition(t *testing.T) {
 		// enumerates 172.16.0.0/12 for a docker bridge silently takes the
 		// bucket away from any real client arriving from inside it
 		"NARROWEST",
+		// and the COMPLETE header contract, not only the header that happened
+		// to trigger this report. This service reads three headers, and which
+		// one a proxy sets differs by product, so an operator who overwrites
+		// the one named above and passes the others through has closed
+		// nothing: the client sets one of the others and picks its own bucket.
+		// This report is what recruits operators into enumerating a proxy at
+		// all, so it is where the whole contract has to be stated.
+		"OVERWRITE OR STRIP ALL THREE", "X-UR-Forwarded-For", "X-Forwarded-Source-Port",
 	} {
 		if !strings.Contains(captured, want) {
 			t.Fatalf(
@@ -757,17 +777,304 @@ func TestUrForwardedForChainIsNotReadAsASingleHop(t *testing.T) {
 		)
 	}
 
-	// X-UR-Forwarded-For still wins over X-Forwarded-For when both are present
-	both := httptest.NewRequest("POST", "/auth/network-create", nil)
-	both.RemoteAddr = ingressProxyAddress
-	both.Header.Set("X-UR-Forwarded-For", "203.0.113.9:41001")
-	both.Header.Set("X-Forwarded-For", "198.51.100.20")
-	got, err = ResolveClientAddress(both, trusted)
+	// This test used to end by pinning "X-UR-Forwarded-For still wins over
+	// X-Forwarded-For when both are present". That pin is deliberately INVERTED
+	// now, because it was the forgery wearing the other header name: on any
+	// deployment whose proxy owns X-Forwarded-For -- Caddy, ALB, CloudFront,
+	// Cloudflare -- the header a CLIENT can set is X-UR-Forwarded-For, so
+	// "X-UR wins" meant the client won. Disagreement between the two headers is
+	// now refused outright, see
+	// TestASecondForwardingHeaderCannotChooseTheBucket, and the shapes where
+	// they AGREE -- what a correctly configured proxy sends -- still resolve
+	// byte for byte as they did, see
+	// TestProxySettingBothForwardingHeadersConsistentlyIsUnchanged.
+}
+
+// bothHeadersRequest is a request from a trusted proxy carrying both forwarding
+// headers, which is what any pass-through proxy delivers as soon as a client
+// decides to set the one the proxy does not overwrite.
+func bothHeadersRequest(headerA string, valueA string, headerB string, valueB string) *http.Request {
+	req := httptest.NewRequest("POST", "/auth/network-create", nil)
+	req.RemoteAddr = ingressProxyAddress
+	req.Header.Set(headerA, valueA)
+	req.Header.Set(headerB, valueB)
+	return req
+}
+
+// TestASecondForwardingHeaderCannotChooseTheBucket is the regression for the
+// forgery that survived the first pass of this fix.
+//
+// This service reads two forwarding headers, and it used to honor whichever one
+// came first in forwardingHeaders -- X-UR-Forwarded-For. A proxy overwrites the
+// header IT sets and, by default, passes every other client header through
+// untouched. So on every deployment whose proxy owns X-Forwarded-For (Caddy,
+// nginx's documented recipe, ALB, CloudFront, Cloudflare), a client that sent
+// its own X-UR-Forwarded-For beat the address the proxy had vouched for and
+// chose its own rate-limit bucket -- stepping outside the 5-per-24h account
+// creation limit and the 5-per-5min auth attempt limit.
+//
+// Reordering the two would only move the hole: the warp load balancer sets
+// X-UR-Forwarded-For (controller/verify_controller.go) and there the
+// client-settable header is X-Forwarded-For. Both deployment shapes exist in
+// this project, so neither header can be declared the authentic one. When they
+// disagree the request is attributed to the PEER instead -- the most
+// restrictive answer available, never an address of the client's choosing.
+func TestASecondForwardingHeaderCannotChooseTheBucket(t *testing.T) {
+	for _, shape := range []struct {
+		what         string
+		proxyHeader  string
+		proxyValue   string
+		clientHeader string
+		clientValue  string
+	}{
+		{
+			"proxy owns X-Forwarded-For (Caddy/ALB/CloudFront/Cloudflare), client sends a bare X-UR-Forwarded-For",
+			"X-Forwarded-For", "203.0.113.9",
+			"X-UR-Forwarded-For", "6.6.6.6",
+		},
+		{
+			"same, with the ip:port form the old code accepted verbatim",
+			"X-Forwarded-For", "203.0.113.9",
+			"X-UR-Forwarded-For", "6.6.6.6:1234",
+		},
+		{
+			"same, with a whole forged chain in the client's header",
+			"X-Forwarded-For", "203.0.113.9",
+			"X-UR-Forwarded-For", "8.8.8.8:1, 6.6.6.6:2",
+		},
+		{
+			"proxy owns X-UR-Forwarded-For (warp load balancer), client sends X-Forwarded-For",
+			"X-UR-Forwarded-For", "203.0.113.9:41001",
+			"X-Forwarded-For", "6.6.6.6",
+		},
+		{
+			"proxy appends to X-Forwarded-For, client still tries the other header",
+			"X-Forwarded-For", "10.0.0.1, 203.0.113.9",
+			"X-UR-Forwarded-For", "6.6.6.6:1234",
+		},
+	} {
+		t.Run(shape.what, func(t *testing.T) {
+			reports := captureProxyReports(t)
+			got, err := ResolveClientAddress(
+				bothHeadersRequest(shape.proxyHeader, shape.proxyValue, shape.clientHeader, shape.clientValue),
+				trustedIngress(),
+			)
+			if err != nil {
+				t.Fatalf(
+					"two forwarding headers returned an error (%v); router.wrap turns that "+
+						"into HTTP 500 on every endpoint",
+					err,
+				)
+			}
+			if ip, _, splitErr := server.SplitClientAddress(got); splitErr == nil && ip == "6.6.6.6" {
+				t.Fatalf(
+					"a client behind a trusted proxy set %s: %q, the proxy vouched for %s: %q, "+
+						"and the api resolved to %q. It just chose its own rate-limit bucket and "+
+						"stepped outside every per-address limit in the service",
+					shape.clientHeader, shape.clientValue, shape.proxyHeader, shape.proxyValue, got,
+				)
+			}
+			if got != ingressProxyAddress {
+				t.Fatalf(
+					"two headers naming two different clients resolved to %q; neither can be "+
+						"shown to be the value the proxy vouched for, so the only safe answer is "+
+						"the peer address %s",
+					got, ingressProxyAddress,
+				)
+			}
+			if len(*reports) != 1 {
+				t.Fatalf(
+					"a trusted proxy passed a client-supplied forwarding header through and %d "+
+						"reports were emitted, want 1: the clients that reach this path share one "+
+						"rate-limit budget and nothing says so\n%s",
+					len(*reports), strings.Join(*reports, "\n"),
+				)
+			}
+			captured := (*reports)[0]
+			for _, want := range []string{"X-Forwarded-For", "X-UR-Forwarded-For", "TRUSTED", "172.18.0.7"} {
+				if !strings.Contains(captured, want) {
+					t.Fatalf(
+						"the conflicting-header report does not mention %q, so an operator cannot "+
+							"tell which peer or which headers to fix\nreport: %s",
+						want, captured,
+					)
+				}
+			}
+			// the header VALUES are client-influenced by definition on this
+			// path -- one of the two came from the client -- so neither may
+			// reach the log
+			for _, forbidden := range []string{"6.6.6.6", "8.8.8.8", "203.0.113.9"} {
+				if strings.Contains(captured, forbidden) {
+					t.Fatalf(
+						"the report echoed a forwarding header value (%s); one of the two is "+
+							"attacker-supplied\nreport: %s",
+						forbidden, captured,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestProxySettingBothForwardingHeadersConsistentlyIsUnchanged is the other
+// half of the test above, and the one that bounds its blast radius.
+//
+// A proxy that sets BOTH headers correctly is a normal configuration -- nginx
+// with proxy_set_header X-UR-Forwarded-For $remote_addr:$remote_port ALONGSIDE
+// X-Forwarded-For $proxy_add_x_forwarded_for -- and the two forms it sends
+// never look identical: one carries a port, the other is a bare ip, and the
+// X-Forwarded-For one carries whatever the client prepended. Refusing on any
+// difference would take the port away from that deployment and move its
+// wallet-challenge and auth-attempt buckets, for nothing. Only the ADDRESS is
+// compared, and where the addresses agree the resolved value is byte for byte
+// what it was before this change.
+func TestProxySettingBothForwardingHeadersConsistentlyIsUnchanged(t *testing.T) {
+	for _, shape := range []struct {
+		what string
+		ur   string
+		xff  string
+		want string
+	}{
+		{
+			"nginx sets X-UR-Forwarded-For=$remote_addr:$remote_port and X-Forwarded-For=$proxy_add_x_forwarded_for",
+			"203.0.113.9:41001", "6.6.6.6, 203.0.113.9", "203.0.113.9:41001",
+		},
+		{
+			"the same pair with nothing prepended by the client",
+			"203.0.113.9:41001", "203.0.113.9", "203.0.113.9:41001",
+		},
+		{
+			"both bare: the port is simply absent, as it is for a lone bare X-Forwarded-For",
+			"203.0.113.9", "203.0.113.9", "203.0.113.9:0",
+		},
+		{
+			"the client's prepended entry is inside the trusted range on one header only",
+			"203.0.113.9:41001", "172.18.0.9, 203.0.113.9", "203.0.113.9:41001",
+		},
+	} {
+		t.Run(shape.what, func(t *testing.T) {
+			reports := captureProxyReports(t)
+			got, err := ResolveClientAddress(
+				bothHeadersRequest("X-UR-Forwarded-For", shape.ur, "X-Forwarded-For", shape.xff),
+				trustedIngress(),
+			)
+			if err != nil {
+				t.Fatalf("a proxy that sets both headers consistently errored: %v", err)
+			}
+			if got != shape.want {
+				t.Fatalf(
+					"X-UR-Forwarded-For %q + X-Forwarded-For %q resolved to %q, want %q. A "+
+						"deployment whose proxy sets both correctly must not lose its client "+
+						"address or its port to the conflict rule",
+					shape.ur, shape.xff, got, shape.want,
+				)
+			}
+			if len(*reports) != 0 {
+				t.Fatalf(
+					"a correctly configured proxy produced %d misconfiguration reports; that "+
+						"buries the reports that are actionable\n%s",
+					len(*reports), strings.Join(*reports, "\n"),
+				)
+			}
+		})
+	}
+
+	// the optional port companion still pairs when both headers carry the bare
+	// form, exactly as it does for a lone bare X-Forwarded-For
+	captureProxyReports(t)
+	withPort := bothHeadersRequest("X-UR-Forwarded-For", "203.0.113.9", "X-Forwarded-For", "203.0.113.9")
+	withPort.Header.Set("X-Forwarded-Source-Port", "41001")
+	got, err := ResolveClientAddress(withPort, trustedIngress())
 	if err != nil {
-		t.Fatalf("both headers: %v", err)
+		t.Fatalf("both bare headers with a source port errored: %v", err)
 	}
 	if got != "203.0.113.9:41001" {
-		t.Fatalf("with both headers set the resolver returned %q, want the X-UR-Forwarded-For value", got)
+		t.Fatalf("both bare headers plus X-Forwarded-Source-Port resolved to %q, want 203.0.113.9:41001", got)
+	}
+}
+
+// TestAHeaderThatNamesNoClientIsNotSteppedOver pins which header decides once
+// two are present and only one of them names anybody.
+//
+// The shape is ordinary internal traffic: one of the deployment's own
+// components, whose address is inside an enumerated CIDR, calls the api through
+// the ingress proxy. The header the proxy sets names that component, every
+// entry in it is a trusted proxy, so it makes no claim this service can honor
+// -- and the component has also sent the other forwarding header.
+//
+// "Use the first header that named somebody" is the natural way to write the
+// multi-header read and it is a forgery: it hands that caller exactly the
+// address it wrote. The FIRST PRESENT header decides, whether or not it named
+// anyone, and the fallback stays the peer.
+func TestAHeaderThatNamesNoClientIsNotSteppedOver(t *testing.T) {
+	reports := captureProxyReports(t)
+
+	got, err := ResolveClientAddress(
+		bothHeadersRequest("X-UR-Forwarded-For", "172.18.0.9:5000", "X-Forwarded-For", "6.6.6.6"),
+		trustedIngress(),
+	)
+	if err != nil {
+		t.Fatalf("an all-trusted first header alongside a second header errored: %v", err)
+	}
+	if got != ingressProxyAddress {
+		t.Fatalf(
+			"the proxy's header named only enumerated hops and the caller's own "+
+				"X-Forwarded-For said 6.6.6.6; the api resolved to %q, want the peer address "+
+				"%s. A caller inside the trusted range just chose its own rate-limit bucket",
+			got, ingressProxyAddress,
+		)
+	}
+	if len(*reports) != 0 {
+		t.Fatalf(
+			"ordinary internal traffic emitted %d reports; nothing here is misconfigured "+
+				"and this buries the reports that are actionable\n%s",
+			len(*reports), strings.Join(*reports, "\n"),
+		)
+	}
+}
+
+// TestEitherForwardingHeaderBeingUnreadableDegradesToThePeer: an unreadable
+// header aborts the whole read, whichever of the two it is.
+//
+// Ignoring the unreadable one and honoring the other looks generous and is the
+// forgery again with an extra step -- the unreadable header can be the PROXY's
+// (that is exactly the condition reportUnusableForwardingHeader exists for) and
+// the readable one the client's. There is no way to tell from here, so neither
+// is honored.
+func TestEitherForwardingHeaderBeingUnreadableDegradesToThePeer(t *testing.T) {
+	for _, shape := range []struct{ what, ur, xff string }{
+		{"the client's header is the unreadable one", "not-an-address", "203.0.113.9"},
+		{"the proxy's header is the unreadable one", "203.0.113.9:41001", "not-an-address"},
+		{"an unreadable entry inside a chain", "203.0.113.9:41001", "6.6.6.6, nonsense, 203.0.113.9,"},
+	} {
+		t.Run(shape.what, func(t *testing.T) {
+			reports := captureProxyReports(t)
+			got, err := ResolveClientAddress(
+				bothHeadersRequest("X-UR-Forwarded-For", shape.ur, "X-Forwarded-For", shape.xff),
+				trustedIngress(),
+			)
+			if err != nil {
+				t.Fatalf("an unreadable header returned an error (%v); router.wrap makes that a 500", err)
+			}
+			if got != ingressProxyAddress {
+				t.Fatalf(
+					"with one header unreadable the resolver returned %q, want the peer address "+
+						"%s: the unreadable one may be the proxy's and the readable one the "+
+						"client's",
+					got, ingressProxyAddress,
+				)
+			}
+			if len(*reports) != 1 {
+				t.Fatalf("want exactly one report, got %d\n%s", len(*reports), strings.Join(*reports, "\n"))
+			}
+			if !strings.Contains((*reports)[0], "could not be read") {
+				t.Fatalf(
+					"an unreadable header was reported as something else; the remedies differ"+
+						"\nreport: %s",
+					(*reports)[0],
+				)
+			}
+		})
 	}
 }
 
@@ -820,6 +1127,21 @@ func TestUnreadableForwardingHeaderFromATrustedPeerDegradesAndIsReported(t *test
 			"the report echoed the attacker-supplied header value; log injection\nreport: %s",
 			(*reports)[0],
 		)
+	}
+	// an operator who lands here is already editing their proxy configuration,
+	// so this report states the same complete header contract as the
+	// unenumerated one -- all three headers, not just the broken one
+	for _, want := range []string{
+		"OVERWRITE OR STRIP ALL THREE", "X-Forwarded-For", "X-UR-Forwarded-For", "X-Forwarded-Source-Port",
+	} {
+		if !strings.Contains((*reports)[0], want) {
+			t.Fatalf(
+				"the unusable-header report does not mention %q, so an operator can fix the "+
+					"header this named and still leave a client-settable one behind"+
+					"\nreport: %s",
+				want, (*reports)[0],
+			)
+		}
 	}
 }
 

--- a/session/client_address_ingress_test.go
+++ b/session/client_address_ingress_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -577,6 +578,11 @@ func TestUnenumeratedProxyReportNamesTheRemedyAndItsPrecondition(t *testing.T) {
 		// operator cannot follow this into a different outage or into a
 		// spoofable configuration
 		"$proxy_add_x_forwarded_for", "last entry", "unchanged",
+		// and the precondition on the CIDR itself: an address inside an
+		// enumerated range is read as a proxy hop, so an operator who
+		// enumerates 172.16.0.0/12 for a docker bridge silently takes the
+		// bucket away from any real client arriving from inside it
+		"NARROWEST",
 	} {
 		if !strings.Contains(captured, want) {
 			t.Fatalf(
@@ -955,6 +961,110 @@ func TestFourInSixAddressesAreOneAddressEverywhere(t *testing.T) {
 	}
 }
 
+// legacyTrustedBranch is the trusted-peer half of ResolveClientAddress as it
+// stood before this change, verbatim, so claims about what the previous
+// implementation did are checked rather than asserted in a comment.
+//
+// Note what is NOT in it: any check of the forwarded VALUE against the trusted
+// set. That absence is the subject of
+// TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket.
+func legacyTrustedBranch(req *http.Request) (string, error) {
+	forwarded := strings.TrimSpace(req.Header.Get("X-UR-Forwarded-For"))
+	if forwarded != "" {
+		if strings.Contains(forwarded, ",") {
+			return "", fmt.Errorf("invalid X-UR-Forwarded-For chain")
+		}
+		address, err := parseRequestAddress(forwarded)
+		if err != nil {
+			return "", fmt.Errorf("invalid X-UR-Forwarded-For: %w", err)
+		}
+		return address.String(), nil
+	}
+	forwardedIp := strings.TrimSpace(req.Header.Get("X-Forwarded-For"))
+	forwardedPort := strings.TrimSpace(req.Header.Get("X-Forwarded-Source-Port"))
+	if forwardedIp == "" && forwardedPort == "" {
+		return "", nil
+	}
+	if forwardedIp == "" || forwardedPort == "" || strings.Contains(forwardedIp, ",") {
+		return "", fmt.Errorf("forwarded source requires one IP and one port")
+	}
+	address, err := parseRequestAddress(net.JoinHostPort(strings.Trim(forwardedIp, "[]"), forwardedPort))
+	if err != nil {
+		return "", fmt.Errorf("invalid forwarded source: %w", err)
+	}
+	return address.String(), nil
+}
+
+// TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket is the ONE
+// behaviour change in this work that is not a 500 being replaced, and it is
+// here so it is not discovered later as a surprise.
+//
+// The previous reader never compared a forwarded value to the trusted set: it
+// took X-UR-Forwarded-For, or X-Forwarded-For + X-Forwarded-Source-Port, and
+// returned it. The new reader walks the chain right to left skipping entries
+// that are themselves inside an enumerated CIDR -- which is what lets it find
+// the client behind two proxy hops, and is the whole reason a client cannot
+// prepend an address of its own. The cost is that a forwarded address INSIDE an
+// enumerated range is now read as a proxy hop rather than as a client.
+//
+// So an operator who enumerates 172.16.0.0/12 because their docker bridge peer
+// is 172.18.0.7 also takes the individual rate-limit bucket away from any real
+// caller arriving from inside 172.16.0.0/12. The direction is conservative --
+// those callers fall back to sharing the proxy's address, they are never
+// attributed to something a caller chose -- but it IS the shared-budget failure
+// this work exists to remove, on a narrow path, so:
+//
+//   - reportUnenumeratedProxy now tells the operator to enumerate the narrowest
+//     range that contains only proxies (pinned by the "NARROWEST" entry in
+//     TestUnenumeratedProxyReportNamesTheRemedyAndItsPrecondition), and
+//   - this test states the trade explicitly instead of leaving it implied by
+//     "nothing that used to resolve resolves differently", which is not true.
+func TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket(t *testing.T) {
+	captureProxyReports(t)
+	trusted := trustedIngress() // 172.16.0.0/12, the natural docker-bridge CIDR
+
+	insideTheRange := "172.20.5.5"
+
+	for _, shape := range []struct {
+		what      string
+		request   *http.Request
+		wasBefore string
+	}{
+		{
+			"X-UR-Forwarded-For naming an address inside the enumerated range",
+			proxiedRequest("X-UR-Forwarded-For", insideTheRange+":41001"),
+			insideTheRange + ":41001",
+		},
+		{
+			"X-Forwarded-For + source port naming an address inside the enumerated range",
+			ingressRequest(insideTheRange, "41001"),
+			insideTheRange + ":41001",
+		},
+	} {
+		before, err := legacyTrustedBranch(shape.request)
+		if err != nil || before != shape.wasBefore {
+			t.Fatalf(
+				"%s: the previous implementation returned (%q, %v), want (%q, nil). This "+
+					"test's whole premise is that this path USED to resolve; re-derive it",
+				shape.what, before, err, shape.wasBefore,
+			)
+		}
+
+		got, err := ResolveClientAddress(shape.request, trusted)
+		if err != nil {
+			t.Fatalf("%s: %v", shape.what, err)
+		}
+		if got != ingressProxyAddress {
+			t.Fatalf(
+				"%s resolved to %q, want the peer %s. If this now resolves to the "+
+					"forwarded address again, the right-to-left walk has stopped skipping "+
+					"enumerated hops and a client can prepend its own address",
+				shape.what, got, ingressProxyAddress,
+			)
+		}
+	}
+}
+
 // TestEveryLoosenedShapeUsedToBeAnHttp500 is the argument that this change
 // cannot regress a working deployment, written as a test.
 //
@@ -964,33 +1074,15 @@ func TestFourInSixAddressesAreOneAddressEverywhere(t *testing.T) {
 // of these paths today is a deployment whose api answers 500 to every request,
 // so there is no working behaviour for the looser contract to take away -- only
 // an outage for it to end.
+//
+// That argument covers the LOOSENING and nothing else. It is not a claim that
+// no previously-working input resolves differently: exactly one does, and
+// TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket is where that
+// one is stated and pinned. Adding it to the table below would fail, because
+// the replica returns it without an error.
 func TestEveryLoosenedShapeUsedToBeAnHttp500(t *testing.T) {
 	captureProxyReports(t)
 	trusted := trustedIngress()
-
-	// the previous implementation, verbatim, so the claim is checked rather
-	// than asserted in a comment
-	oldResolve := func(req *http.Request) error {
-		forwarded := strings.TrimSpace(req.Header.Get("X-UR-Forwarded-For"))
-		if forwarded != "" {
-			if strings.Contains(forwarded, ",") {
-				return fmt.Errorf("invalid X-UR-Forwarded-For chain")
-			}
-			if _, err := parseRequestAddress(forwarded); err != nil {
-				return fmt.Errorf("invalid X-UR-Forwarded-For: %w", err)
-			}
-			return nil
-		}
-		forwardedIp := strings.TrimSpace(req.Header.Get("X-Forwarded-For"))
-		forwardedPort := strings.TrimSpace(req.Header.Get("X-Forwarded-Source-Port"))
-		if forwardedIp == "" && forwardedPort == "" {
-			return nil
-		}
-		if forwardedIp == "" || forwardedPort == "" || strings.Contains(forwardedIp, ",") {
-			return fmt.Errorf("forwarded source requires one IP and one port")
-		}
-		return nil
-	}
 
 	for _, shape := range []struct {
 		what   string
@@ -1005,7 +1097,7 @@ func TestEveryLoosenedShapeUsedToBeAnHttp500(t *testing.T) {
 		{"an unreadable header from a trusted proxy", "X-Forwarded-For", "not-an-address"},
 	} {
 		req := proxiedRequest(shape.header, shape.value)
-		if err := oldResolve(req); err == nil {
+		if _, err := legacyTrustedBranch(req); err == nil {
 			t.Fatalf(
 				"%s (%s: %s) did NOT error on the previous implementation, so this test "+
 					"is no longer evidence that the looser contract only replaces 500s -- "+

--- a/session/client_address_test.go
+++ b/session/client_address_test.go
@@ -36,17 +36,56 @@ func TestResolveClientAddressTrustBoundary(t *testing.T) {
 	}
 }
 
-func TestResolveClientAddressRejectsChainsAndPartialHeaders(t *testing.T) {
+// TestResolveClientAddressReadsChainsAndPartialHeaders replaces a test that
+// asserted the opposite, and the replacement is deliberate.
+//
+// It used to read:
+//
+//	req.Header.Set("X-UR-Forwarded-For", "192.0.2.1:1, 192.0.2.2:2")
+//	if _, err := ResolveClientAddress(req, trusted); err == nil {
+//	        t.Fatal("forwarded chain accepted")
+//	}
+//	req.Header.Set("X-Forwarded-For", "192.0.2.1")
+//	if _, err := ResolveClientAddress(req, trusted); err == nil {
+//	        t.Fatal("partial forwarded identity accepted")
+//	}
+//
+// Rejecting is safe in the sense that no address is forged, but the rejection
+// is an ERROR, and router.wrap / router.wrapWithInput turn a session
+// construction failure into HTTP 500 for every endpoint. Both shapes above are
+// what real proxies send: nginx with the documented
+// proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for sends a bare
+// X-Forwarded-For with no source port, and appends a comma on the second hop.
+// So the old contract meant "enumerate your ingress proxy in
+// BRINGYOUR_TRUSTED_PROXY_CIDRS" and "keep the api up" were mutually
+// exclusive.
+//
+// Both are now read, and the chain is read from the RIGHT: the entry a trusted
+// hop appended, never the entry a client prepended. See
+// TestClientCannotForgeItsAddressThroughATrustedProxy, which is where that
+// property is pinned properly.
+func TestResolveClientAddressReadsChainsAndPartialHeaders(t *testing.T) {
+	captureProxyReports(t)
 	trusted := []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "127.0.0.1:8080"
 	req.Header.Set("X-UR-Forwarded-For", "192.0.2.1:1, 192.0.2.2:2")
-	if _, err := ResolveClientAddress(req, trusted); err == nil {
-		t.Fatal("forwarded chain accepted")
+	got, err := ResolveClientAddress(req, trusted)
+	if err != nil {
+		t.Fatalf("a forwarded chain from a trusted peer errored (HTTP 500 on every endpoint): %v", err)
 	}
+	if got != "192.0.2.2:2" {
+		t.Fatalf("forwarded chain resolved to %q, want the last hop 192.0.2.2:2", got)
+	}
+
 	req.Header.Del("X-UR-Forwarded-For")
 	req.Header.Set("X-Forwarded-For", "192.0.2.1")
-	if _, err := ResolveClientAddress(req, trusted); err == nil {
-		t.Fatal("partial forwarded identity accepted")
+	got, err = ResolveClientAddress(req, trusted)
+	if err != nil {
+		t.Fatalf("a bare X-Forwarded-For from a trusted peer errored (HTTP 500 on every endpoint): %v", err)
+	}
+	if got != "192.0.2.1:0" {
+		t.Fatalf("bare X-Forwarded-For resolved to %q, want 192.0.2.1:0", got)
 	}
 }

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -328,7 +328,11 @@ func reportUnenumeratedProxy(peer netip.Addr, header string, trusted []netip.Pre
 			"optionally with X-Forwarded-Source-Port, or X-UR-Forwarded-For as "+
 			"ip:port. This service reads the last entry of the chain, so a proxy "+
 			"that appends is safe and a proxy that forwards the client's own value "+
-			"unchanged lets that client choose its rate-limit bucket. If %s is not a "+
+			"unchanged lets that client choose its rate-limit bucket. Enumerate the "+
+			"NARROWEST range that contains only proxies: an address inside an "+
+			"enumerated CIDR is read as a proxy hop rather than as a client, so any "+
+			"real client arriving from inside that range loses its own rate-limit "+
+			"bucket and shares the proxy's. If %s is not a "+
 			"proxy of this deployment then a client is sending a forwarding header "+
 			"it is not entitled to: the header is correctly ignored and no "+
 			"configuration change is wanted.\n",
@@ -501,9 +505,23 @@ func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, er
 		return remote.String(), nil
 	}
 	if !found {
-		// every hop in the chain is itself a trusted proxy, so the client is
-		// one of this deployment's own components. The peer address is the
-		// correct answer and there is nothing to report.
+		// Every entry in the chain is inside an enumerated CIDR. That is
+		// usually one of this deployment's own components calling in through
+		// the proxy, in which case the peer address is the right answer and
+		// there is nothing to report. It can ALSO be a real client whose
+		// address happens to fall inside a range the operator enumerated, and
+		// that client has just lost its own rate-limit bucket and joined the
+		// proxy's -- the shared-budget failure this file exists to prevent, on
+		// a narrow path.
+		//
+		// It is not reported, because the two are indistinguishable from here
+		// and the first is ordinary traffic: an alert on every internal call
+		// would bury the reports that are actionable. The remedy belongs to the
+		// operator and reportUnenumeratedProxy states it -- enumerate the
+		// narrowest range that contains only proxies. Note this is the ONE
+		// place the new reader is more conservative than the old one, which
+		// never checked a forwarded value against the trusted set at all; see
+		// TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket.
 		return remote.String(), nil
 	}
 	if port == 0 {

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -111,6 +111,18 @@ func parseRequestAddress(raw string) (netip.AddrPort, error) {
 		// this, proxyIsTrusted (which unmaps) and server.ClientIpHashForAddr
 		// (which does not) disagree about what host a request came from, and
 		// one host holds two per-address budgets and two report slots.
+		//
+		// One-time effect when this ships, stated because it is a LOOSENING
+		// and the rest of this change is not. netip treats a 4-in-6 address as
+		// ipv6 (Is4 is false for it), so server.ClientIpHashForAddr masks such
+		// a client under the /56 rule -- and the first 7 bytes of the 4-in-6
+		// form are all zero, so every 4-in-6 client on the deployment hashes
+		// to the SAME bucket and shares one budget. After the Unmap they split
+		// into their real per-/29 buckets, i.e. each of them gets a fresh
+		// account-creation budget on the day this deploys. It is the same
+		// wrongly-collapsed bucket being un-collapsed that this branch exists
+		// for, and reachability is low (Go renders ipv4 peers in ipv4 form),
+		// but it is worth knowing before it lands rather than after.
 		return netip.AddrPortFrom(addrPort.Addr().Unmap(), addrPort.Port()), nil
 	}
 	host, port, err := net.SplitHostPort(raw)

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -187,6 +187,11 @@ const (
 	// one address, which is the same fleet-wide-budget failure, just on the
 	// other side of the trust boundary
 	proxyReportUnusableHeader proxyReportKind = "unusable-forwarding-header"
+	// a TRUSTED peer sent two forwarding headers naming two DIFFERENT clients:
+	// only one of them can be the value that peer observed, nothing here can
+	// tell which, and the difference means the proxy is passing a
+	// client-supplied header through
+	proxyReportConflictingHeaders proxyReportKind = "conflicting-forwarding-headers"
 )
 
 type proxyReportKey struct {
@@ -285,6 +290,31 @@ func resetProxyReports() {
 	proxyReportPruneScans = 0
 }
 
+// proxyForwardingHeaderContract is the sentence every operator-facing report
+// carries: the COMPLETE set of headers a trusted proxy has to own, not just
+// the one that triggered the report.
+//
+// Naming only the triggering header is what left the hole this constant
+// closes. This service reads two forwarding headers and a port companion, and
+// which one a deployment's proxy owns differs -- the warp load balancer writes
+// X-UR-Forwarded-For (see controller/verify_controller.go), while Caddy, nginx
+// and every managed load balancer write X-Forwarded-For. So an operator who
+// overwrites the one header a report named, and passes the others through, has
+// closed nothing: the client sets the other one and picks its own rate-limit
+// bucket. There is no preference this service could enforce instead, because
+// either choice would be the forgery in one of the two deployment shapes; the
+// resolver refuses to guess (see conflictingCandidates) and the remedy is
+// stated here as all three.
+//
+// It is a const so it is part of the format string, never an argument.
+const proxyForwardingHeaderContract = "OVERWRITE OR STRIP ALL THREE of the " +
+	"headers this service reads -- X-Forwarded-For, X-UR-Forwarded-For and " +
+	"X-Forwarded-Source-Port -- not only the one named here. Which of them a " +
+	"proxy sets differs by product, and any of the three that arrives from " +
+	"the client unchanged lets that client choose its own rate-limit bucket: " +
+	"nginx `proxy_set_header X-UR-Forwarded-For \"\";`, Caddy `header_up " +
+	"-X-UR-Forwarded-For`. "
+
 // glogErrorf is a var so a test can read a report's actual text rather than
 // asserting only that some report happened. It is also the single seam the
 // report tests drive: nothing stubs the report functions themselves, so the
@@ -328,7 +358,9 @@ func reportUnenumeratedProxy(peer netip.Addr, header string, trusted []netip.Pre
 			"optionally with X-Forwarded-Source-Port, or X-UR-Forwarded-For as "+
 			"ip:port. This service reads the last entry of the chain, so a proxy "+
 			"that appends is safe and a proxy that forwards the client's own value "+
-			"unchanged lets that client choose its rate-limit bucket. Enumerate the "+
+			"unchanged lets that client choose its rate-limit bucket. "+
+			proxyForwardingHeaderContract+
+			"Enumerate the "+
 			"NARROWEST range that contains only proxies: an address inside an "+
 			"enumerated CIDR is read as a proxy hop rather than as a client, so any "+
 			"real client arriving from inside that range loses its own rate-limit "+
@@ -372,9 +404,57 @@ func reportUnusableForwardingHeader(peer netip.Addr, header string, trusted []ne
 			"trusted by %s (currently %v), so this is the proxy's header, not a "+
 			"client's: it must send X-Forwarded-For as one ip per hop (a bare ip is "+
 			"fine, X-Forwarded-Source-Port is optional) or X-UR-Forwarded-For as "+
-			"ip:port. The value is not logged here because a proxy that forwards "+
+			"ip:port. "+
+			proxyForwardingHeaderContract+
+			"The value is not logged here because a proxy that forwards "+
 			"client headers makes it client-controlled.\n",
 		header,
+		peer,
+		peer,
+		trustedProxyCidrsEnvironment,
+		trusted,
+	)
+}
+
+// reportConflictingForwardingHeaders names a TRUSTED peer that sent two
+// forwarding headers pointing at two different clients.
+//
+// That is a proxy passing a client-supplied header through. A correctly
+// configured proxy leaves exactly one usable value for this service to read;
+// when two disagree, one of them was written by the client, and which one
+// cannot be told apart from here -- the warp load balancer owns
+// X-UR-Forwarded-For while Caddy and the managed load balancers own
+// X-Forwarded-For, so neither header is inherently the authentic one.
+//
+// The request is attributed to the peer, so the condition costs the client its
+// own rate-limit bucket rather than handing it a bucket of its choosing, and
+// it is reported because that fallback is the same shared-budget collapse the
+// rest of this file exists to prevent.
+//
+// The header VALUES are not logged, for the same reason as the two reports
+// above: both are client-influenced here by definition. Only the two header
+// NAMES are interpolated, and those come from forwardingHeaders, which is a
+// package constant list.
+func reportConflictingForwardingHeaders(peer netip.Addr, headerA string, headerB string, trusted []netip.Prefix) {
+	if !shouldReportProxy(proxyReportKey{peer: peer, kind: proxyReportConflictingHeaders}, time.Now()) {
+		return
+	}
+	glogErrorf(
+		"[session]%s and %s from TRUSTED peer %s named two DIFFERENT client "+
+			"addresses, so NEITHER was honored and the request was attributed to "+
+			"%s itself -- the most restrictive answer available. Only one of those "+
+			"headers can be the address that peer observed, and this service "+
+			"cannot tell which, so a client that sets the header the proxy does "+
+			"not overwrite would otherwise choose its own rate-limit budget. Every "+
+			"client that reaches this path shares one client address and therefore "+
+			"one budget, so signup and login can be refused for users who did "+
+			"nothing. The peer is trusted by %s (currently %v), so this is the "+
+			"proxy's configuration to fix: "+
+			proxyForwardingHeaderContract+
+			"The header values are not logged here because a proxy that forwards "+
+			"client headers makes them client-controlled.\n",
+		headerA,
+		headerB,
 		peer,
 		peer,
 		trustedProxyCidrsEnvironment,
@@ -464,6 +544,85 @@ func forwardedSourcePort(req *http.Request, chain string) (uint16, bool) {
 	return uint16(portNumber), true
 }
 
+// forwardedCandidate is one forwarding header's answer about who the client is.
+type forwardedCandidate struct {
+	header string
+	chain  string
+	addr   netip.Addr
+	port   uint16
+	// found is false when every entry in the chain is a trusted proxy, i.e.
+	// the header makes no claim about a client this service should honor
+	found bool
+}
+
+// forwardedCandidates reads EVERY forwarding header present on the request, in
+// forwardingHeaders order, rather than only the first one.
+//
+// Reading only the first is what let a client choose its own bucket. On a
+// deployment whose proxy owns X-Forwarded-For -- Caddy, ALB, CloudFront,
+// Cloudflare -- a client that also sends X-UR-Forwarded-For had the first slot
+// in that list, so its own value won over the one the proxy vouched for. The
+// mirror shape is a deployment whose proxy owns X-UR-Forwarded-For (the warp
+// load balancer): there the client-supplied header is X-Forwarded-For.
+// Reordering the list only moves the hole between the two shapes, so both are
+// read and disagreement is refused instead.
+//
+// A malformed header aborts the whole read, whichever header it is. Ignoring
+// the malformed one and honoring the other would be the forgery again with an
+// extra step: the unreadable header could be the proxy's, and the readable one
+// the client's.
+func forwardedCandidates(req *http.Request, trusted []netip.Prefix) (candidates []forwardedCandidate, malformedHeader string) {
+	for _, header := range forwardingHeaders {
+		chain := forwardingHeaderChain(req, header)
+		if chain == "" {
+			continue
+		}
+		addr, port, found, malformed := forwardedClientAddr(chain, trusted)
+		if malformed {
+			return nil, header
+		}
+		candidates = append(candidates, forwardedCandidate{
+			header: header,
+			chain:  chain,
+			addr:   addr,
+			port:   port,
+			found:  found,
+		})
+	}
+	return candidates, ""
+}
+
+// conflictingCandidates finds two headers that name two different clients.
+//
+// Only the ADDRESS is compared, deliberately. A proxy that sets both headers
+// correctly sets them in different forms -- X-UR-Forwarded-For as ip:port and
+// X-Forwarded-For as a bare ip, whose port reads as 0 -- so requiring the ports
+// to match too would call the correctly configured deployment a conflict and
+// drop it to the peer address. Port handling is therefore left exactly as it
+// was: the first present header decides it. The residual client influence over
+// the port on a proxy that passes X-Forwarded-Source-Port through is unchanged
+// by this function and is stated in proxyForwardingHeaderContract.
+//
+// Candidates with found == false are skipped: they name no client, so they
+// cannot disagree with one.
+func conflictingCandidates(candidates []forwardedCandidate) (first forwardedCandidate, other forwardedCandidate, conflict bool) {
+	claimed := false
+	for _, candidate := range candidates {
+		if !candidate.found {
+			continue
+		}
+		if !claimed {
+			first = candidate
+			claimed = true
+			continue
+		}
+		if first.addr != candidate.addr {
+			return first, candidate, true
+		}
+	}
+	return forwardedCandidate{}, forwardedCandidate{}, false
+}
+
 // ResolveClientAddress honors forwarding headers only when the immediate TCP
 // peer is in an explicit trusted CIDR. This makes source attribution an
 // application invariant instead of relying solely on an ingress rewrite.
@@ -494,17 +653,31 @@ func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, er
 		return remote.String(), nil
 	}
 
-	header := forwardingHeaderPresent(req)
-	if header == "" {
+	candidates, malformedHeader := forwardedCandidates(req, trusted)
+	if malformedHeader != "" {
+		reportUnusableForwardingHeader(remote.Addr(), malformedHeader, trusted)
 		return remote.String(), nil
 	}
-	chain := forwardingHeaderChain(req, header)
-	addr, port, found, malformed := forwardedClientAddr(chain, trusted)
-	if malformed {
-		reportUnusableForwardingHeader(remote.Addr(), header, trusted)
+	if len(candidates) == 0 {
 		return remote.String(), nil
 	}
-	if !found {
+	if first, other, conflict := conflictingCandidates(candidates); conflict {
+		// Two headers, two different clients. One of them is a value the proxy
+		// is passing through from the client, and nothing here can tell which,
+		// so neither is honored -- see reportConflictingForwardingHeaders.
+		reportConflictingForwardingHeaders(remote.Addr(), first.header, other.header, trusted)
+		return remote.String(), nil
+	}
+
+	// The FIRST present header still decides, exactly as before. Where the
+	// headers agree there is nothing to choose between; where they disagree the
+	// request has already been refused above. What must NOT happen is stepping
+	// PAST a first header that names no client (found == false, every entry
+	// inside an enumerated CIDR) to honor a later one: on a deployment whose
+	// proxy owns X-UR-Forwarded-For, that is a caller inside the trusted range
+	// getting its own X-Forwarded-For honored.
+	decisive := candidates[0]
+	if !decisive.found {
 		// Every entry in the chain is inside an enumerated CIDR. That is
 		// usually one of this deployment's own components calling in through
 		// the proxy, in which case the peer address is the right answer and
@@ -524,12 +697,13 @@ func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, er
 		// TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket.
 		return remote.String(), nil
 	}
+	port := decisive.port
 	if port == 0 {
-		if sourcePort, ok := forwardedSourcePort(req, chain); ok {
+		if sourcePort, ok := forwardedSourcePort(req, decisive.chain); ok {
 			port = sourcePort
 		}
 	}
-	return netip.AddrPortFrom(addr, port).String(), nil
+	return netip.AddrPortFrom(decisive.addr, port).String(), nil
 }
 
 func NewLocalClientSession(ctx context.Context, clientAddress string, byJwt *jwt.ByJwt) *ClientSession {

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -274,10 +274,22 @@ var (
 // distinct /29s or /56s inside one interval to get there -- not, as it did
 // before the key was bucketed, that many individual addresses out of one
 // residential /64. It is acceptable because the failure mode is fewer log
-// lines, never a wrong address: in the deployment this exists to diagnose, the
-// wedged proxy is essentially all of the traffic, so it wins the token on
-// nearly every pass. TestGenuineReportSurvivesAFloodOfDistinctPeers is that
-// claim as a test.
+// lines, never a wrong address.
+//
+// Be precise about WHY a wedged proxy keeps reporting under a flood, because
+// the obvious explanation is wrong: it is not that it wins the single global
+// token. The prune at the bottom of this function evicts an entry once
+// proxyReportInterval has elapsed, so at an interval boundary the wedged
+// entry is dropped and whichever peer arrives first takes the token. What
+// actually keeps it reporting is the seen-branch refreshing its key on every
+// request, ahead of the prune -- and in the deployment this exists to
+// diagnose, the wedged proxy is essentially all of the traffic.
+//
+// So a boundary-timed flood CAN starve the diagnostic. That costs an attacker
+// at least 1024 sustained distinct /29s or /56s, and the cost of success is
+// fewer log lines -- never a wrong address, never a rate-limit budget, never
+// a spoof. It is recorded rather than fixed because tightening the prune to
+// buy the property back would trade a real bound for a diagnostic nicety.
 func shouldReportProxy(key proxyReportKey, now time.Time) bool {
 	key.peer = proxyReportPeerBucket(key.peer)
 

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -14,6 +14,7 @@ import (
 	// "strconv"
 	"strings"
 	"sync"
+	"time"
 	// "sync"
 
 	// "bytes"
@@ -132,6 +133,104 @@ func proxyIsTrusted(remote netip.Addr, trusted []netip.Prefix) bool {
 	return false
 }
 
+// forwardingHeaders are the headers ResolveClientAddress honors from a trusted
+// peer. Their presence on a request from an UNTRUSTED peer is the
+// misconfiguration signal reported below.
+var forwardingHeaders = []string{"X-UR-Forwarded-For", "X-Forwarded-For"}
+
+func forwardingHeaderPresent(req *http.Request) string {
+	for _, header := range forwardingHeaders {
+		if strings.TrimSpace(req.Header.Get(header)) != "" {
+			return header
+		}
+	}
+	return ""
+}
+
+// unenumeratedProxyReportInterval bounds the report once every distinct peer
+// has already been named. A wedged deployment stays loud for as long as it is
+// wedged -- this path never stops firing -- while no caller can flood the log.
+const unenumeratedProxyReportInterval = time.Minute
+
+// unenumeratedProxyReportedMax bounds the memory the per-peer suppression can
+// take. Any client can set a forwarding header on a directly reachable api, so
+// the set of peers that reach the report is caller-influenced and must not
+// grow without limit.
+const unenumeratedProxyReportedMax = 1024
+
+var (
+	unenumeratedProxyMutex    sync.Mutex
+	unenumeratedProxyReported = map[netip.Addr]bool{}
+	unenumeratedProxyLastAt   time.Time
+)
+
+// shouldReportUnenumeratedProxy rate limits the report to once per distinct
+// peer while the bounded set has room, and to once per interval after that.
+func shouldReportUnenumeratedProxy(peer netip.Addr, now time.Time) bool {
+	unenumeratedProxyMutex.Lock()
+	defer unenumeratedProxyMutex.Unlock()
+
+	if !unenumeratedProxyReported[peer] && len(unenumeratedProxyReported) < unenumeratedProxyReportedMax {
+		unenumeratedProxyReported[peer] = true
+		unenumeratedProxyLastAt = now
+		return true
+	}
+	if now.Sub(unenumeratedProxyLastAt) < unenumeratedProxyReportInterval {
+		return false
+	}
+	unenumeratedProxyLastAt = now
+	return true
+}
+
+// resetUnenumeratedProxyReports clears the suppression state so one test's
+// report does not silence the next.
+func resetUnenumeratedProxyReports() {
+	unenumeratedProxyMutex.Lock()
+	defer unenumeratedProxyMutex.Unlock()
+	unenumeratedProxyReported = map[netip.Addr]bool{}
+	unenumeratedProxyLastAt = time.Time{}
+}
+
+// glogErrorf is a var so a test can read the report's actual text rather than
+// asserting only that some report happened.
+var glogErrorf = glog.Errorf
+
+// reportUnenumeratedProxy names a peer that sent a forwarding header this
+// service will not honor. It is a var so tests can observe the report without
+// scraping the log.
+//
+// This exists because the failure it reports is otherwise silent and total. If
+// the deployment's ingress proxy is not enumerated in
+// BRINGYOUR_TRUSTED_PROXY_CIDRS then every request resolves to that proxy's own
+// address, every per-address budget in the service collapses into one budget
+// for the whole fleet, and the only symptom is legitimate users refused for
+// something strangers did. Nothing else in the service can tell that apart from
+// real abuse.
+//
+// The report deliberately does NOT trust the peer. Honoring a forwarding header
+// from an unenumerated peer would let any client claim any source address and
+// step outside every per-address limit in the service.
+var reportUnenumeratedProxy = func(peer netip.Addr, header string, trusted []netip.Prefix) {
+	if !shouldReportUnenumeratedProxy(peer, time.Now()) {
+		return
+	}
+	glogErrorf(
+		"[session]%s from untrusted peer %s was IGNORED. If %s is this deployment's "+
+			"ingress proxy then it is missing from %s (currently %v) and EVERY client "+
+			"behind it now shares one client address and therefore one rate-limit "+
+			"budget -- signup and login will be refused for users who did nothing. "+
+			"Add its subnet. If %s is not a proxy of this deployment then a client is "+
+			"sending a forwarding header it is not entitled to: the header is "+
+			"correctly ignored and no configuration change is wanted.\n",
+		header,
+		peer,
+		peer,
+		trustedProxyCidrsEnvironment,
+		trusted,
+		peer,
+	)
+}
+
 // ResolveClientAddress honors forwarding headers only when the immediate TCP
 // peer is in an explicit trusted CIDR. This makes source attribution an
 // application invariant instead of relying solely on an ingress rewrite.
@@ -141,6 +240,13 @@ func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, er
 		return "", fmt.Errorf("invalid remote address %q: %w", req.RemoteAddr, err)
 	}
 	if !proxyIsTrusted(remote.Addr(), trusted) {
+		// The header is not honored -- see reportUnenumeratedProxy -- but its
+		// presence means either the deployment forgot to enumerate its ingress
+		// proxy, which silently collapses every per-address budget onto one
+		// address, or a client is spoofing. Both are worth saying out loud.
+		if header := forwardingHeaderPresent(req); header != "" {
+			reportUnenumeratedProxy(remote.Addr(), header, trusted)
+		}
 		return remote.String(), nil
 	}
 

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -198,6 +198,12 @@ var (
 	proxyReportMutex  sync.Mutex
 	proxyReportedAt   = map[proxyReportKey]time.Time{}
 	proxyReportLastAt time.Time
+	proxyReportPruned time.Time
+	// proxyReportPruneScans counts prune passes so a test can assert the scan
+	// stays amortized. The scan runs under the global mutex on a path any
+	// caller can trigger, so one scan per request while the map is full would
+	// be a contention amplifier aimed at whoever is keeping it full.
+	proxyReportPruneScans int
 )
 
 // shouldReportProxy rate limits an operator report to once per interval per
@@ -230,7 +236,24 @@ func shouldReportProxy(key proxyReportKey, now time.Time) bool {
 		return true
 	}
 
-	if proxyReportedMax <= len(proxyReportedAt) {
+	// Prune at most once per interval.
+	//
+	// Not because a more frequent scan would find nothing -- entries are
+	// written at different times and so age out continuously, and a scan a
+	// second later can free one the previous scan could not. Because the scan
+	// walks the whole map while holding this process-global mutex, on a path
+	// any caller who can reach the api directly can trigger, so an unguarded
+	// scan hands the caller who is keeping the map full an O(cap) critical
+	// section per request: a contention amplifier built out of the flood guard.
+	//
+	// The prune is best-effort reclamation, not a correctness mechanism, which
+	// is what makes rate-limiting it safe. An entry that lingers past its
+	// interval only delays reuse of one slot; memory is bounded by the cap
+	// either way, and the tier below keeps the report firing while the map is
+	// full, so nothing goes silent while a prune is being deferred.
+	if proxyReportedMax <= len(proxyReportedAt) && proxyReportInterval <= now.Sub(proxyReportPruned) {
+		proxyReportPruned = now
+		proxyReportPruneScans += 1
 		for staleKey, lastAt := range proxyReportedAt {
 			if proxyReportInterval <= now.Sub(lastAt) {
 				delete(proxyReportedAt, staleKey)
@@ -258,6 +281,8 @@ func resetProxyReports() {
 	defer proxyReportMutex.Unlock()
 	proxyReportedAt = map[proxyReportKey]time.Time{}
 	proxyReportLastAt = time.Time{}
+	proxyReportPruned = time.Time{}
+	proxyReportPruneScans = 0
 }
 
 // glogErrorf is a var so a test can read a report's actual text rather than

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -211,6 +211,42 @@ type proxyReportKey struct {
 	kind proxyReportKind
 }
 
+// proxyReportPeerV4Prefix and proxyReportPeerV6Prefix bucket the peer in the
+// suppression key by NETWORK rather than by address.
+//
+// They are the prefixes server.ClientIpHashForAddr already uses to decide what
+// counts as one client (/29 v4, /56 v6); nothing in ip.go changes, this reuses
+// the same answer. Without it the key unmapped the peer but did not mask it,
+// so a caller could buy a fresh report slot with every source address it
+// owned: measured, a single ipv6 /64 -- an ordinary residential allocation --
+// sustained the whole proxyReportedMax cap of 1024 report lines per interval,
+// 1754 bytes each, about 2.6 GB a day of glog.Errorf. Bucketed, the same
+// caller gets 1 line per interval. Since it cannot buy extra rate-limit budget
+// by rotating inside its /29 or /56, it should not be able to buy extra log
+// volume with it either.
+//
+// Coarser would be worse than the flood: two genuinely different unenumerated
+// proxies must not silence each other, or the report stops naming the proxy an
+// operator has to fix. /29 and /56 are the granularity this service already
+// treats as one host.
+const (
+	proxyReportPeerV4Prefix = 29
+	proxyReportPeerV6Prefix = 56
+)
+
+func proxyReportPeerBucket(peer netip.Addr) netip.Addr {
+	// unmap first, exactly as proxyIsTrusted does, so a 4-in-6 peer and the
+	// same host in plain ipv4 are one bucket and not two
+	peer = peer.Unmap()
+	if peer.Is4() {
+		return netip.PrefixFrom(peer, proxyReportPeerV4Prefix).Masked().Addr()
+	}
+	if peer.Is6() {
+		return netip.PrefixFrom(peer, proxyReportPeerV6Prefix).Masked().Addr()
+	}
+	return peer
+}
+
 var (
 	proxyReportMutex  sync.Mutex
 	proxyReportedAt   = map[proxyReportKey]time.Time{}
@@ -224,22 +260,26 @@ var (
 )
 
 // shouldReportProxy rate limits an operator report to once per interval per
-// (peer, condition).
+// (peer NETWORK, condition) -- see proxyReportPeerBucket for why the key is a
+// network and not an address.
 //
 // The timestamp map is only written when a report is actually emitted, so it
 // cannot grow faster than one entry per emitted line, and entries older than
 // the interval are pruned once it reaches its cap. Should a burst of distinct
-// peers fill it anyway, the report degrades to a single global token per
-// interval rather than either going silent or growing without bound.
+// peer networks fill it anyway, the report degrades to a single global token
+// per interval rather than either going silent or growing without bound.
 //
 // That global-token tier is the one place a caller who can reach the api
 // directly can starve the signal, and it costs them more than proxyReportedMax
-// distinct source addresses inside one interval to get there. It is acceptable
-// because the failure mode is fewer log lines, never a wrong address: in the
-// deployment this exists to diagnose, the wedged proxy is essentially all of
-// the traffic, so it wins the token on nearly every pass.
+// distinct /29s or /56s inside one interval to get there -- not, as it did
+// before the key was bucketed, that many individual addresses out of one
+// residential /64. It is acceptable because the failure mode is fewer log
+// lines, never a wrong address: in the deployment this exists to diagnose, the
+// wedged proxy is essentially all of the traffic, so it wins the token on
+// nearly every pass. TestGenuineReportSurvivesAFloodOfDistinctPeers is that
+// claim as a test.
 func shouldReportProxy(key proxyReportKey, now time.Time) bool {
-	key.peer = key.peer.Unmap()
+	key.peer = proxyReportPeerBucket(key.peer)
 
 	proxyReportMutex.Lock()
 	defer proxyReportMutex.Unlock()
@@ -332,6 +372,24 @@ const proxyForwardingHeaderContract = "OVERWRITE OR STRIP ALL THREE of the " +
 // report tests drive: nothing stubs the report functions themselves, so the
 // rate limiting below is exercised by the same tests that count reports.
 var glogErrorf = glog.Errorf
+
+// The three reports below print the peer's FULL address, unhashed, and that is
+// deliberate rather than an oversight. Everywhere this service PERSISTS a
+// client address it stores server.ClientIpHash instead (and
+// db_migrations_code.go blanks the raw values that predate that), so these are
+// the one place a client address is written out in plaintext.
+//
+// The reason is that the address is the remedy. Every one of these reports asks
+// an operator to enumerate a CIDR in BRINGYOUR_TRUSTED_PROXY_CIDRS or to fix a
+// specific proxy, and neither is actionable from a hash -- a report that says
+// "some peer is misconfigured" diagnoses nothing. The scope is bounded by what
+// reaches these paths: only a peer that sent a forwarding header, at most once
+// per interval per network, and never the header VALUE, which is the part a
+// client controls.
+//
+// If that trade ever needs revisiting, the thing to change is the destination
+// (an operator-only sink) rather than the content, because a bucketed or hashed
+// address here would leave the failure these exist to diagnose undiagnosable.
 
 // reportUnenumeratedProxy names a peer that sent a forwarding header this
 // service will not honor.

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -106,7 +106,12 @@ func ParseTrustedProxyPrefixes(raw string) ([]netip.Prefix, error) {
 
 func parseRequestAddress(raw string) (netip.AddrPort, error) {
 	if addrPort, err := netip.ParseAddrPort(raw); err == nil {
-		return addrPort, nil
+		// Unmap so a 4-in-6 peer ([::ffff:203.0.113.9]) and the same host
+		// arriving as plain ipv4 are one address everywhere downstream. Without
+		// this, proxyIsTrusted (which unmaps) and server.ClientIpHashForAddr
+		// (which does not) disagree about what host a request came from, and
+		// one host holds two per-address budgets and two report slots.
+		return netip.AddrPortFrom(addrPort.Addr().Unmap(), addrPort.Port()), nil
 	}
 	host, port, err := net.SplitHostPort(raw)
 	if err != nil {
@@ -138,66 +143,131 @@ func proxyIsTrusted(remote netip.Addr, trusted []netip.Prefix) bool {
 // misconfiguration signal reported below.
 var forwardingHeaders = []string{"X-UR-Forwarded-For", "X-Forwarded-For"}
 
+// forwardingHeaderChain is the whole of one forwarding header, as one chain.
+//
+// Header.Get would return only the FIRST field line, and RFC 9110 makes
+// repeated field lines equivalent to one comma-joined line. A proxy that
+// appends a second X-Forwarded-For line instead of extending the first is
+// entirely legal, and reading only the first line there would hand back a
+// value the CLIENT sent while discarding the one the proxy vouched for --
+// the exact forgery forwardedClientAddr walks right-to-left to prevent.
+func forwardingHeaderChain(req *http.Request, header string) string {
+	return strings.TrimSpace(strings.Join(req.Header.Values(header), ","))
+}
+
 func forwardingHeaderPresent(req *http.Request) string {
 	for _, header := range forwardingHeaders {
-		if strings.TrimSpace(req.Header.Get(header)) != "" {
+		if forwardingHeaderChain(req, header) != "" {
 			return header
 		}
 	}
 	return ""
 }
 
-// unenumeratedProxyReportInterval bounds the report once every distinct peer
-// has already been named. A wedged deployment stays loud for as long as it is
-// wedged -- this path never stops firing -- while no caller can flood the log.
-const unenumeratedProxyReportInterval = time.Minute
+// proxyReportInterval bounds how often one peer is named for one condition.
+// A wedged deployment stays loud for as long as it is wedged -- these paths
+// never stop firing -- while no caller can flood the log.
+const proxyReportInterval = time.Minute
 
-// unenumeratedProxyReportedMax bounds the memory the per-peer suppression can
-// take. Any client can set a forwarding header on a directly reachable api, so
-// the set of peers that reach the report is caller-influenced and must not
-// grow without limit.
-const unenumeratedProxyReportedMax = 1024
+// proxyReportedMax bounds the memory the suppression map can take. Any client
+// can set a forwarding header on a directly reachable api, so the set of peers
+// that reach a report is caller-influenced and must not grow without limit.
+const proxyReportedMax = 1024
 
-var (
-	unenumeratedProxyMutex    sync.Mutex
-	unenumeratedProxyReported = map[netip.Addr]bool{}
-	unenumeratedProxyLastAt   time.Time
+// proxyReportKind separates the two operator-facing conditions so one does not
+// suppress the other for the same peer. They have different remedies.
+type proxyReportKind string
+
+const (
+	// an UNTRUSTED peer sent a forwarding header: either the deployment forgot
+	// to enumerate its ingress proxy, or a client is spoofing
+	proxyReportUnenumerated proxyReportKind = "unenumerated-proxy"
+	// a TRUSTED peer sent a forwarding header this service cannot read: the
+	// client identity is lost and every client behind that proxy collapses onto
+	// one address, which is the same fleet-wide-budget failure, just on the
+	// other side of the trust boundary
+	proxyReportUnusableHeader proxyReportKind = "unusable-forwarding-header"
 )
 
-// shouldReportUnenumeratedProxy rate limits the report to once per distinct
-// peer while the bounded set has room, and to once per interval after that.
-func shouldReportUnenumeratedProxy(peer netip.Addr, now time.Time) bool {
-	unenumeratedProxyMutex.Lock()
-	defer unenumeratedProxyMutex.Unlock()
+type proxyReportKey struct {
+	peer netip.Addr
+	kind proxyReportKind
+}
 
-	if !unenumeratedProxyReported[peer] && len(unenumeratedProxyReported) < unenumeratedProxyReportedMax {
-		unenumeratedProxyReported[peer] = true
-		unenumeratedProxyLastAt = now
+var (
+	proxyReportMutex  sync.Mutex
+	proxyReportedAt   = map[proxyReportKey]time.Time{}
+	proxyReportLastAt time.Time
+)
+
+// shouldReportProxy rate limits an operator report to once per interval per
+// (peer, condition).
+//
+// The timestamp map is only written when a report is actually emitted, so it
+// cannot grow faster than one entry per emitted line, and entries older than
+// the interval are pruned once it reaches its cap. Should a burst of distinct
+// peers fill it anyway, the report degrades to a single global token per
+// interval rather than either going silent or growing without bound.
+//
+// That global-token tier is the one place a caller who can reach the api
+// directly can starve the signal, and it costs them more than proxyReportedMax
+// distinct source addresses inside one interval to get there. It is acceptable
+// because the failure mode is fewer log lines, never a wrong address: in the
+// deployment this exists to diagnose, the wedged proxy is essentially all of
+// the traffic, so it wins the token on nearly every pass.
+func shouldReportProxy(key proxyReportKey, now time.Time) bool {
+	key.peer = key.peer.Unmap()
+
+	proxyReportMutex.Lock()
+	defer proxyReportMutex.Unlock()
+
+	if lastAt, seen := proxyReportedAt[key]; seen {
+		if now.Sub(lastAt) < proxyReportInterval {
+			return false
+		}
+		proxyReportedAt[key] = now
+		proxyReportLastAt = now
 		return true
 	}
-	if now.Sub(unenumeratedProxyLastAt) < unenumeratedProxyReportInterval {
-		return false
+
+	if proxyReportedMax <= len(proxyReportedAt) {
+		for staleKey, lastAt := range proxyReportedAt {
+			if proxyReportInterval <= now.Sub(lastAt) {
+				delete(proxyReportedAt, staleKey)
+			}
+		}
 	}
-	unenumeratedProxyLastAt = now
+	if proxyReportedMax <= len(proxyReportedAt) {
+		// the map is full of entries that are all still inside the interval
+		if now.Sub(proxyReportLastAt) < proxyReportInterval {
+			return false
+		}
+		proxyReportLastAt = now
+		return true
+	}
+
+	proxyReportedAt[key] = now
+	proxyReportLastAt = now
 	return true
 }
 
-// resetUnenumeratedProxyReports clears the suppression state so one test's
-// report does not silence the next.
-func resetUnenumeratedProxyReports() {
-	unenumeratedProxyMutex.Lock()
-	defer unenumeratedProxyMutex.Unlock()
-	unenumeratedProxyReported = map[netip.Addr]bool{}
-	unenumeratedProxyLastAt = time.Time{}
+// resetProxyReports clears the suppression state so one test's report does not
+// silence the next.
+func resetProxyReports() {
+	proxyReportMutex.Lock()
+	defer proxyReportMutex.Unlock()
+	proxyReportedAt = map[proxyReportKey]time.Time{}
+	proxyReportLastAt = time.Time{}
 }
 
-// glogErrorf is a var so a test can read the report's actual text rather than
-// asserting only that some report happened.
+// glogErrorf is a var so a test can read a report's actual text rather than
+// asserting only that some report happened. It is also the single seam the
+// report tests drive: nothing stubs the report functions themselves, so the
+// rate limiting below is exercised by the same tests that count reports.
 var glogErrorf = glog.Errorf
 
 // reportUnenumeratedProxy names a peer that sent a forwarding header this
-// service will not honor. It is a var so tests can observe the report without
-// scraping the log.
+// service will not honor.
 //
 // This exists because the failure it reports is otherwise silent and total. If
 // the deployment's ingress proxy is not enumerated in
@@ -210,8 +280,15 @@ var glogErrorf = glog.Errorf
 // The report deliberately does NOT trust the peer. Honoring a forwarding header
 // from an unenumerated peer would let any client claim any source address and
 // step outside every per-address limit in the service.
-var reportUnenumeratedProxy = func(peer netip.Addr, header string, trusted []netip.Prefix) {
-	if !shouldReportUnenumeratedProxy(peer, time.Now()) {
+//
+// The remedy it prints is the whole remedy. An operator who enumerates the
+// subnet and stops there must not end up worse off, so the message also states
+// what the proxy has to send and, more importantly, what it must NOT do:
+// forward a client-supplied value unchanged. The attacker-supplied header
+// VALUE is never logged -- only the header name, which is one of two package
+// constants.
+func reportUnenumeratedProxy(peer netip.Addr, header string, trusted []netip.Prefix) {
+	if !shouldReportProxy(proxyReportKey{peer: peer, kind: proxyReportUnenumerated}, time.Now()) {
 		return
 	}
 	glogErrorf(
@@ -219,21 +296,159 @@ var reportUnenumeratedProxy = func(peer netip.Addr, header string, trusted []net
 			"ingress proxy then it is missing from %s (currently %v) and EVERY client "+
 			"behind it now shares one client address and therefore one rate-limit "+
 			"budget -- signup and login will be refused for users who did nothing. "+
-			"Add its subnet. If %s is not a proxy of this deployment then a client is "+
-			"sending a forwarding header it is not entitled to: the header is "+
-			"correctly ignored and no configuration change is wanted.\n",
+			"Add its subnet to %s. That proxy must also OVERWRITE the forwarding "+
+			"header with the address of the connection it received, not pass a "+
+			"client-supplied value through: send X-Forwarded-For (nginx "+
+			"$proxy_add_x_forwarded_for, or any ALB/CloudFront/Cloudflare default), "+
+			"optionally with X-Forwarded-Source-Port, or X-UR-Forwarded-For as "+
+			"ip:port. This service reads the last entry of the chain, so a proxy "+
+			"that appends is safe and a proxy that forwards the client's own value "+
+			"unchanged lets that client choose its rate-limit bucket. If %s is not a "+
+			"proxy of this deployment then a client is sending a forwarding header "+
+			"it is not entitled to: the header is correctly ignored and no "+
+			"configuration change is wanted.\n",
 		header,
 		peer,
 		peer,
 		trustedProxyCidrsEnvironment,
 		trusted,
+		trustedProxyCidrsEnvironment,
 		peer,
 	)
+}
+
+// reportUnusableForwardingHeader names a TRUSTED peer whose forwarding header
+// could not be read.
+//
+// This is the report that keeps the degrade-instead-of-error behaviour in
+// ResolveClientAddress honest. Before, an unreadable header from a trusted peer
+// returned an error that wrapWithInput and wrap both turn into HTTP 500 for
+// every endpoint -- loud, but a total outage. Falling back to the peer address
+// instead cannot be wrong (the peer is the address the packets actually came
+// from, the most restrictive answer available) but it silently reintroduces the
+// exact fleet-wide-budget collapse this file exists to prevent. So it is not
+// silent.
+//
+// The header VALUE is deliberately not logged: it is attacker-influenced on any
+// proxy that forwards client headers, and this format string is a constant.
+func reportUnusableForwardingHeader(peer netip.Addr, header string, trusted []netip.Prefix) {
+	if !shouldReportProxy(proxyReportKey{peer: peer, kind: proxyReportUnusableHeader}, time.Now()) {
+		return
+	}
+	glogErrorf(
+		"[session]%s from TRUSTED peer %s could not be read as a client address, so "+
+			"the client address fell back to %s itself. Every client behind that peer "+
+			"now shares one client address and therefore one rate-limit budget -- "+
+			"signup and login will be refused for users who did nothing. The peer is "+
+			"trusted by %s (currently %v), so this is the proxy's header, not a "+
+			"client's: it must send X-Forwarded-For as one ip per hop (a bare ip is "+
+			"fine, X-Forwarded-Source-Port is optional) or X-UR-Forwarded-For as "+
+			"ip:port. The value is not logged here because a proxy that forwards "+
+			"client headers makes it client-controlled.\n",
+		header,
+		peer,
+		peer,
+		trustedProxyCidrsEnvironment,
+		trusted,
+	)
+}
+
+// parseForwardedElement reads one entry of a forwarding header. Real proxies
+// disagree about the form: nginx, ALB, CloudFront and Cloudflare all write a
+// bare ip into X-Forwarded-For, the warp sidecar writes ip:port into
+// X-UR-Forwarded-For, and some proxies write ip:port into X-Forwarded-For for
+// ipv4. All four are accepted; a missing port comes back as 0.
+//
+// ParseAddr is tried before ParseAddrPort deliberately: a bare ipv6 is full of
+// colons, and reading "2001:db8::7" as host:port would be wrong.
+func parseForwardedElement(raw string) (netip.Addr, uint16, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return netip.Addr{}, 0, false
+	}
+	if addr, err := netip.ParseAddr(raw); err == nil {
+		return addr.Unmap(), 0, true
+	}
+	if addr, err := netip.ParseAddr(strings.Trim(raw, "[]")); err == nil {
+		return addr.Unmap(), 0, true
+	}
+	if addrPort, err := parseRequestAddress(raw); err == nil {
+		return addrPort.Addr(), addrPort.Port(), true
+	}
+	return netip.Addr{}, 0, false
+}
+
+// forwardedClientAddr reads the client address a trusted peer vouched for.
+//
+// The chain is walked RIGHT TO LEFT, skipping entries that are themselves
+// trusted proxies, and the first entry that is not a trusted proxy wins. That
+// direction is the whole security property. A proxy appends what it observed to
+// the right (nginx's $proxy_add_x_forwarded_for, and every managed load
+// balancer), so everything to the LEFT of the entry a trusted hop wrote is a
+// value the client supplied. Reading left to right -- taking "the original
+// client" -- would let any client behind the proxy prepend an address of its
+// choosing and pick its own rate-limit bucket. Reading right to left, a client
+// that sends "X-Forwarded-For: 6.6.6.6" gets "6.6.6.6, <its real ip>" and is
+// attributed to its real ip.
+//
+// found is false when no entry survives: either every entry is a trusted proxy
+// (the client genuinely is one), or an entry could not be parsed at all. The
+// two are told apart by malformed, because only the second is worth reporting.
+// Walking stops at the first unparseable entry rather than skipping it, because
+// an entry that cannot be read cannot be shown to be a trusted hop, and
+// stepping over it is exactly the step that walks into client-controlled text.
+func forwardedClientAddr(chain string, trusted []netip.Prefix) (addr netip.Addr, port uint16, found bool, malformed bool) {
+	elements := strings.Split(chain, ",")
+	for i := len(elements) - 1; 0 <= i; i -= 1 {
+		elementAddr, elementPort, ok := parseForwardedElement(elements[i])
+		if !ok {
+			return netip.Addr{}, 0, false, true
+		}
+		if proxyIsTrusted(elementAddr, trusted) {
+			continue
+		}
+		return elementAddr, elementPort, true, false
+	}
+	return netip.Addr{}, 0, false, false
+}
+
+// forwardedSourcePort reads the optional companion header that carries the
+// client's source port for a bare X-Forwarded-For.
+//
+// It is honored only for a single-hop chain, which is exactly the shape the
+// previous implementation required, so the pairing this service already
+// documented keeps its meaning and nothing new is inferred from it. On a longer
+// chain the port belongs to whichever hop wrote it and there is no way to tell
+// which, so it is dropped rather than guessed.
+func forwardedSourcePort(req *http.Request, chain string) (uint16, bool) {
+	if strings.Contains(chain, ",") {
+		return 0, false
+	}
+	raw := strings.TrimSpace(req.Header.Get("X-Forwarded-Source-Port"))
+	if raw == "" {
+		return 0, false
+	}
+	portNumber, err := net.LookupPort("tcp", raw)
+	if err != nil || portNumber < 0 || 65535 < portNumber {
+		return 0, false
+	}
+	return uint16(portNumber), true
 }
 
 // ResolveClientAddress honors forwarding headers only when the immediate TCP
 // peer is in an explicit trusted CIDR. This makes source attribution an
 // application invariant instead of relying solely on an ingress rewrite.
+//
+// A forwarding header this service cannot read is never an error. It used to
+// be, and that error became HTTP 500 on every endpoint (router.wrap and
+// router.wrapWithInput both turn a session construction failure into a 500), so
+// an operator who enumerated a stock nginx -- which sends a bare
+// X-Forwarded-For with no X-Forwarded-Source-Port, and appends a comma on the
+// second hop -- took the whole api down by following the advice in
+// reportUnenumeratedProxy. Both of those shapes are now read correctly; anything
+// still unreadable falls back to the peer address, which is where the packets
+// actually came from and therefore the most restrictive answer available, and
+// is reported loudly rather than served as a 500.
 func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, error) {
 	remote, err := parseRequestAddress(req.RemoteAddr)
 	if err != nil {
@@ -250,31 +465,28 @@ func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, er
 		return remote.String(), nil
 	}
 
-	forwarded := strings.TrimSpace(req.Header.Get("X-UR-Forwarded-For"))
-	if forwarded != "" {
-		if strings.Contains(forwarded, ",") {
-			return "", fmt.Errorf("invalid X-UR-Forwarded-For chain")
-		}
-		address, err := parseRequestAddress(forwarded)
-		if err != nil {
-			return "", fmt.Errorf("invalid X-UR-Forwarded-For: %w", err)
-		}
-		return address.String(), nil
-	}
-
-	forwardedIp := strings.TrimSpace(req.Header.Get("X-Forwarded-For"))
-	forwardedPort := strings.TrimSpace(req.Header.Get("X-Forwarded-Source-Port"))
-	if forwardedIp == "" && forwardedPort == "" {
+	header := forwardingHeaderPresent(req)
+	if header == "" {
 		return remote.String(), nil
 	}
-	if forwardedIp == "" || forwardedPort == "" || strings.Contains(forwardedIp, ",") {
-		return "", fmt.Errorf("forwarded source requires one IP and one port")
+	chain := forwardingHeaderChain(req, header)
+	addr, port, found, malformed := forwardedClientAddr(chain, trusted)
+	if malformed {
+		reportUnusableForwardingHeader(remote.Addr(), header, trusted)
+		return remote.String(), nil
 	}
-	address, err := parseRequestAddress(net.JoinHostPort(strings.Trim(forwardedIp, "[]"), forwardedPort))
-	if err != nil {
-		return "", fmt.Errorf("invalid forwarded source: %w", err)
+	if !found {
+		// every hop in the chain is itself a trusted proxy, so the client is
+		// one of this deployment's own components. The peer address is the
+		// correct answer and there is nothing to report.
+		return remote.String(), nil
 	}
-	return address.String(), nil
+	if port == 0 {
+		if sourcePort, ok := forwardedSourcePort(req, chain); ok {
+			port = sourcePort
+		}
+	}
+	return netip.AddrPortFrom(addr, port).String(), nil
 }
 
 func NewLocalClientSession(ctx context.Context, clientAddress string, byJwt *jwt.ByJwt) *ClientSession {

--- a/session/client_session.go
+++ b/session/client_session.go
@@ -615,8 +615,22 @@ func forwardedCandidates(req *http.Request, trusted []netip.Prefix) (candidates 
 // the port on a proxy that passes X-Forwarded-Source-Port through is unchanged
 // by this function and is stated in proxyForwardingHeaderContract.
 //
-// Candidates with found == false are skipped: they name no client, so they
-// cannot disagree with one.
+// Candidates with found == false are skipped HERE, and refused by
+// candidateNamesNoClient instead. This function is only the REPORTED condition
+// -- two headers that each name a client and name different ones -- because a
+// report is a resource a client must not be able to spend. Behind a trusted
+// proxy the peer is one address for every client, so the (peer, condition)
+// suppression slot is shared; a client can produce a header that names no
+// client whenever it likes, so reporting that shape would let it take the slot
+// every interval and silence the genuine both-named conflict from a real
+// misconfiguration. Both shapes resolve to the peer either way, so nothing is
+// lost by keeping one of them quiet.
+//
+// Note that with two entries in forwardingHeaders, a candidate with
+// found == false means at most ONE candidate has found == true, so this
+// function provably cannot fire for any request candidateNamesNoClient
+// catches: the split changes which shapes are refused, never which are
+// reported.
 func conflictingCandidates(candidates []forwardedCandidate) (first forwardedCandidate, other forwardedCandidate, conflict bool) {
 	claimed := false
 	for _, candidate := range candidates {
@@ -633,6 +647,44 @@ func conflictingCandidates(candidates []forwardedCandidate) (first forwardedCand
 		}
 	}
 	return forwardedCandidate{}, forwardedCandidate{}, false
+}
+
+// candidateNamesNoClient reports whether any PRESENT forwarding header names no
+// client at all -- every entry in its chain is inside an enumerated CIDR.
+//
+// Such a header is not neutral. It is a claim, by a header this deployment
+// reads, that the client is a trusted hop; it disagrees with any other header
+// that names a real client, and the answer when two headers disagree is the
+// peer address. Treating it as "makes no claim, so it cannot disagree" is what
+// let a client behind a trusted proxy pick its own bucket: the proxy wrote
+// X-Forwarded-For: <an address inside the enumerated range>, the client wrote
+// X-UR-Forwarded-For: 6.6.6.6, only the client's header named anybody, and the
+// client got 6.6.6.6.
+//
+// EVERY candidate is checked, not just the first. The first-only version
+// guarded one of the two deployment shapes and left its mirror open, and which
+// header a proxy owns differs by product -- the warp load balancer writes
+// X-UR-Forwarded-For, Caddy and the managed load balancers write
+// X-Forwarded-For -- so a rule that holds for only one ordering holds for
+// neither deployment.
+//
+// The discriminating question is whether a legitimate deployment sends one
+// header naming a client while the other names only enumerated hops, and the
+// answer is no in the direction this closes. The warp sidecar writes
+// X-UR-Forwarded-For as $remote_addr:$remote_port, i.e. the peer IT sees: if
+// X-UR-Forwarded-For names a real client then that sidecar is the edge, so
+// there is no inner enumerated hop that could have written an all-enumerated
+// X-Forwarded-For, and that header came from the client. The mirror direction
+// (X-UR names only enumerated hops, X-Forwarded-For names a client -- warp
+// nginx behind an enumerated CDN) already resolved to the peer before this
+// change, via the first-candidate guard, so it loses nothing it had.
+func candidateNamesNoClient(candidates []forwardedCandidate) bool {
+	for _, candidate := range candidates {
+		if !candidate.found {
+			return true
+		}
+	}
+	return false
 }
 
 // ResolveClientAddress honors forwarding headers only when the immediate TCP
@@ -681,34 +733,39 @@ func ResolveClientAddress(req *http.Request, trusted []netip.Prefix) (string, er
 		return remote.String(), nil
 	}
 
-	// The FIRST present header still decides, exactly as before. Where the
-	// headers agree there is nothing to choose between; where they disagree the
-	// request has already been refused above. What must NOT happen is stepping
-	// PAST a first header that names no client (found == false, every entry
-	// inside an enumerated CIDR) to honor a later one: on a deployment whose
-	// proxy owns X-UR-Forwarded-For, that is a caller inside the trusted range
-	// getting its own X-Forwarded-For honored.
-	decisive := candidates[0]
-	if !decisive.found {
-		// Every entry in the chain is inside an enumerated CIDR. That is
-		// usually one of this deployment's own components calling in through
-		// the proxy, in which case the peer address is the right answer and
-		// there is nothing to report. It can ALSO be a real client whose
-		// address happens to fall inside a range the operator enumerated, and
-		// that client has just lost its own rate-limit bucket and joined the
-		// proxy's -- the shared-budget failure this file exists to prevent, on
-		// a narrow path.
+	if candidateNamesNoClient(candidates) {
+		// At least one present header names no client -- every entry in its
+		// chain is inside an enumerated CIDR. That is usually one of this
+		// deployment's own components calling in through the proxy, in which
+		// case the peer address is the right answer and there is nothing to
+		// report. It can ALSO be a real client whose address happens to fall
+		// inside a range the operator enumerated, and that client has just lost
+		// its own rate-limit bucket and joined the proxy's -- the shared-budget
+		// failure this file exists to prevent, on a narrow path.
 		//
-		// It is not reported, because the two are indistinguishable from here
-		// and the first is ordinary traffic: an alert on every internal call
-		// would bury the reports that are actionable. The remedy belongs to the
-		// operator and reportUnenumeratedProxy states it -- enumerate the
-		// narrowest range that contains only proxies. Note this is the ONE
-		// place the new reader is more conservative than the old one, which
-		// never checked a forwarded value against the trusted set at all; see
+		// Either way it is the answer for the WHOLE request, not just for that
+		// header: a second header that does name a client cannot be honored
+		// over it, because on this shape the header that names the client is
+		// the client's own (see candidateNamesNoClient). Honoring it is exactly
+		// how a client behind a trusted proxy picked its own bucket.
+		//
+		// It is not reported, because the internal-call case and the
+		// client-inside-the-range case are indistinguishable from here, the
+		// first is ordinary traffic, and a client can produce this shape on
+		// demand -- so a report here would be a suppression slot the client
+		// gets to spend. The remedy belongs to the operator and
+		// reportUnenumeratedProxy states it: enumerate the narrowest range that
+		// contains only proxies. Note this is the ONE place the new reader is
+		// more conservative than the old one, which never checked a forwarded
+		// value against the trusted set at all; see
 		// TestForwardedAddressInsideAnEnumeratedCidrSharesTheProxyBucket.
 		return remote.String(), nil
 	}
+
+	// The FIRST present header decides, exactly as before. Every present header
+	// names a client and they all name the SAME one by now -- disagreement was
+	// refused above, in both of its forms -- so this chooses only the port.
+	decisive := candidates[0]
 	port := decisive.port
 	if port == 0 {
 		if sourcePort, ok := forwardedSourcePort(req, decisive.chain); ok {


### PR DESCRIPTION
Signup is currently refusing first-time users on production. Reproduced on both deployments from an address that had created one account in ten days:

```
POST https://api.bringyour.com/auth/network-create        -> 429
POST https://beta.app.ur.network/api/auth/network-create  -> 429
"You have reached the maximum number of account creations for today."
```

## Root cause

`ResolveClientAddress` returns the immediate peer's address when that peer is not in `trustedProxyPrefixes()`. `BRINGYOUR_TRUSTED_PROXY_CIDRS` appears exactly once in the repo — its own const — and is never set, so the default is loopback only while the ingress proxy arrives from a bridge address. Every request in the deployment therefore resolves to one address and shares one budget of 5. The window is sliding, not calendar-day, so **it never resets**: once five creates land the deployment stays wedged.

The Caddyfile sets `X-Forwarded-Source-Port` specifically so "the same address feeds rate limiting" — and the trust gate returns before that header is ever read.

## What this changes

**1. The misconfiguration is now loud.** An unenumerated peer arriving with forwarding headers is reported, naming the peer, the header, the current trusted set and the env var — and naming the other possibility (a client sending a header it is not entitled to) so an operator is not misled into whitelisting a spoofer. The peer is **not** auto-trusted; resolution is unchanged. Rate limited per bucketed peer, then per interval.

**2. Standard proxies no longer 500.** A first version of this warning told operators to enumerate the proxy — but the trusted branch required `X-UR-Forwarded-For` as `ip:port`, or `X-Forwarded-For` **plus** `X-Forwarded-Source-Port`, single-hop. Stock nginx, ALB, CloudFront and Cloudflare send a bare `X-Forwarded-For`, and `$proxy_add_x_forwarded_for` appends, so two hops add a rejected comma. That path became `HTTP 500` for every endpoint — following the log line would have taken the API down. A bare `X-Forwarded-For` from an enumerated proxy is now handled, pinned at the HTTP boundary by `TestEnumeratedProxySendingOnlyBareXForwardedForIsNotA500`.

**3. `503` -> `429` for the auth-attempt limiter.** 7 call sites across login, verify, code sends and password reset. A 5xx tells every SDK the server is broken and to retry, and every attempt including rejected ones is recorded — so retries were self-reinforcing.

**4. Validation mistakes no longer spend budget.** The limiter moved below terms, name validation and availability. A taken network name or an unticked terms box was consuming an address-wide slot. Nothing that mutates state sits above the limiter.

**5. Honest refusals, with `Retry-After`.** The message told users who had created nothing that they had hit their limit. Wording is parameterized on `userAuth`, because a blanket "address-scoped" claim is false at 5 of the 7 sites — only the nil-userAuth key is genuinely shared. Account creation computes the real remaining window.

## Deliberately not changed

The `/29` and `/56` masking, every limit value, and the default trusted set. Those are anti-abuse policy, not defects — widening them is your call, not something to slip into a fix. `ip.go` is untouched.

## Verification

Three adversarial review rounds; the final one **ran the suite** rather than reading it, and re-ran each mutation first-hand. 8 deliberate breaks, each watched going red — including both HIGH findings from earlier rounds, proved closed at the HTTP boundary rather than by inspecting message text.

The suite shows 13 failures in `model` and `api/handlers`. All 13 were re-run on a pristine `upstream/main` tree and **fail identically there** (payments/leaderboard/subsidy and a missing `apple_roots.pem`). **Zero new failures.** All 10 new model regression tests and both new handler tests pass when run explicitly.

Two LOW findings are recorded rather than hidden: a comment overclaiming why the diagnostic survives a flood is corrected in the final commit, and `TestConfiguredAppleRootCertificates` panics the whole `api/handlers` binary on a missing optional config — pre-existing on upstream, but it means this branch's own status-code tests are skipped in a full-package run unless that file is present.

## Deploy note

The code makes the wedge visible; the fix is to set `BRINGYOUR_TRUSTED_PROXY_CIDRS` to the ingress proxy's range. The beta `api` service has no `env_file` key, so it cannot currently be injected there at all.